### PR TITLE
Fix authRequired widening, unstable form field keys, and a stale sdk constraint

### DIFF
--- a/jetsclient/lib/components/data_table.dart
+++ b/jetsclient/lib/components/data_table.dart
@@ -824,10 +824,6 @@ class JetsDataTableState extends FormFieldState<WidgetField> {
       //   download(utf8.encode('Mapping for $client and $org for object type $objectType, mapping contains ${model!.length} rows'), downloadName: 'mapping.txt');
 
       //   break;
-
-      default:
-        showAlertDialog(
-            context, 'Oops something is wrong, unknown action ${ac.key}');
     }
   }
 

--- a/jetsclient/lib/models/form_config.dart
+++ b/jetsclient/lib/models/form_config.dart
@@ -305,7 +305,7 @@ class FormInputFieldConfig extends FormFieldConfig {
     required JetsFormState formState,
   }) {
     return JetsTextFormField(
-      key: UniqueKey(),
+      key: ValueKey('$group::$key'),
       formFieldConfig: this,
       onChanged: (p0) {
         formState.setValueAndNotify(group, key, p0.isNotEmpty ? p0 : null);
@@ -363,7 +363,7 @@ class FormDropdownFieldConfig extends FormFieldConfig {
     required JetsFormState formState,
   }) {
     return JetsDropdownButtonFormField(
-      key: UniqueKey(),
+      key: ValueKey('$group::$key'),
       screenPath: screenPath,
       formFieldConfig: this,
       onChanged: (p0) => formState.setValueAndNotify(group, key, p0),
@@ -411,7 +411,7 @@ class FormDropdownWithSharedItemsFieldConfig extends FormFieldConfig {
     required JetsFormState formState,
   }) {
     return JetsDropdownWithSharedItemsFormField(
-      key: UniqueKey(),
+      key: ValueKey('$group::$key'),
       screenPath: screenPath,
       formFieldConfig: this,
       onChanged: (p0) => formState.setValueAndNotify(group, key, p0),
@@ -450,7 +450,7 @@ class FormTypeaheadFieldConfig extends FormFieldConfig {
     required JetsFormState formState,
   }) {
     return JetsTypeaheadFormField(
-      key: UniqueKey(),
+      key: ValueKey('$group::$key'),
       formFieldConfig: this,
       onChanged: (p0) {
         formState.setValueAndNotify(group, key, p0.isNotEmpty ? p0 : null);
@@ -487,7 +487,7 @@ class FormDataTableFieldConfig extends FormFieldConfig {
         width: tableWidth,
         height: tableHeight,
         child: JetsDataTableWidget(
-            key: UniqueKey(),
+            key: ValueKey('$group::$key'),
             screenPath: screenPath,
             formFieldConfig: this,
             tableConfig: getTableConfig(dataTableConfig),
@@ -548,7 +548,7 @@ class FormActionConfig extends FormFieldConfig {
     required JetsFormState formState,
   }) {
     return JetsFormButton(
-        key: UniqueKey(),
+        key: ValueKey('$group::$key'),
         formActionConfig: this,
         formKey: formState.formKey!,
         formState: formState,

--- a/jetsclient/lib/models/user_flow_config.dart
+++ b/jetsclient/lib/models/user_flow_config.dart
@@ -189,9 +189,6 @@ class Expression extends UserFlowChoice {
           return lhs.contains(rhs);
         }
         return false;
-
-      default:
-        return false;
     }
   }
 }

--- a/jetsclient/lib/modules/workspace_ide/screen_delegates_helpers.dart
+++ b/jetsclient/lib/modules/workspace_ide/screen_delegates_helpers.dart
@@ -75,8 +75,23 @@ Future<String?> openWorkspaceActions(
   return null;
 }
 
+/// Files of this size or larger are not opened in the Workspace IDE.
+///
+/// The editor is a single Flutter text field, and Flutter lays a text field's
+/// whole document out on every frame rather than virtualising it by line, so
+/// the cost grows with the size of the file instead of with the part of it on
+/// screen. Past roughly this size the screen stops being usable, so
+/// [mapMenuEntry] drops both the route and the menu action below — which is
+/// why an oversized file's menu entry does nothing at all when clicked rather
+/// than opening slowly.
+///
+/// Raising this number on its own therefore trades a clear failure for an
+/// unusable screen; it can only go up once the editor itself virtualises.
+const workspaceFileEditorSizeLimit = 250000;
+
 // Utility function to create MenuEntry recursively
-// Note: Cap file size to 120K (120000), larger than that we don't bring them in ui
+// Note: files at or above [workspaceFileEditorSizeLimit] are listed but not
+// openable — see that constant for why.
 // Note: MenuEntry.formConfigKey is constructed from e['type'] and e['key']
 // (file, data_model, jet_rules, lookups)
 // It is used in initializeWorkspaceFileEditor to get the formConfig to use.
@@ -108,11 +123,14 @@ List<MenuEntry> mapMenuEntry(List<dynamic> data) {
     return MenuEntry(
       key: pageMatchKey ?? '',
       label: '${e!["label"] ?? ''} (${size/1000}Kb)',
-      routePath:
-          size < 250000 ? (routePath.isNotEmpty ? routePath : null) : null,
+      routePath: size < workspaceFileEditorSizeLimit
+          ? (routePath.isNotEmpty ? routePath : null)
+          : null,
       pageMatchKey: pageMatchKey,
       routeParams: e!["route_params"],
-      menuAction: size < 250000 ? initializeWorkspaceFileEditor : null,
+      menuAction: size < workspaceFileEditorSizeLimit
+          ? initializeWorkspaceFileEditor
+          : null,
       formConfigKey: formConfigKey,
       onPageStyle: onPageStyle,
       otherPageStyle: otherPageStyle,

--- a/jetsclient/lib/routes/jets_route_data.dart
+++ b/jetsclient/lib/routes/jets_route_data.dart
@@ -1,9 +1,22 @@
+import 'package:jetsclient/routes/jets_routes_app.dart';
+
 class JetsRouteData {
   final String path;
   final Map<String, dynamic> params;
 
-  bool get authRequired =>
-      !(path.contains('login') || path.contains('register'));
+  /// The paths reachable without an authenticated session.
+  ///
+  /// An exact match, deliberately, rather than a substring test. [path] is
+  /// always a route template taken from [jetsRoutesMap] — `jetsRoutesParser`
+  /// either matches a template and returns it verbatim, or falls through to
+  /// [pageNotFoundPath] — so a substring test buys nothing. What it cost was
+  /// safety: the previous
+  /// `path.contains('login') || path.contains('register')` would have made
+  /// *any* future route public the moment its path happened to contain either
+  /// word.
+  static const publicPaths = <String>{loginPath, registerPath};
+
+  bool get authRequired => !publicPaths.contains(path);
 
   const JetsRouteData(this.path, {Map<String, dynamic>? params})
       : params = params ?? const {};

--- a/jetsclient/lib/screens/base_screen.dart
+++ b/jetsclient/lib/screens/base_screen.dart
@@ -177,30 +177,19 @@ class BaseScreenState extends State<BaseScreen> with TickerProviderStateMixin {
     final ThemeData themeData = Theme.of(context);
     final dropdownItems = [DropdownItemConfig(label: 'Filter Client')];
     dropdownItems.addAll(JetsRouterDelegate().clients);
-    List<MenuEntry> menuEntries = [];
-
-    switch (widget.screenConfig.type) {
-      case ScreenType.home:
-        // Home screen and all (pipeline) config & operational pages
-        menuEntries = JetsRouterDelegate().user.isAdmin
-            ? widget.screenConfig.adminMenuEntries
-            : widget.screenConfig.menuEntries;
-        break;
-      case ScreenType.other:
-        menuEntries = JetsRouterDelegate().user.isAdmin
-            ? widget.screenConfig.adminMenuEntries
-            : widget.screenConfig.menuEntries;
-        break;
-      case ScreenType.workspace:
-        // All workspace IDE screens
-        // All screens with workspace content in left menu tree
-        menuEntries = JetsRouterDelegate().workspaceMenuState;
-        break;
-      default:
-        // unknown
-        print(
-            'Oops unknown widget.screenConfig.type: ${widget.screenConfig.type}');
-    }
+    // A switch expression rather than a statement, so that adding a
+    // [ScreenType] is a compile error here rather than a screen that renders an
+    // empty menu and says nothing about why.
+    final List<MenuEntry> menuEntries = switch (widget.screenConfig.type) {
+      // The home screen, all (pipeline) config and operational pages, and the
+      // remaining non-workspace screens, which choose their menu the same way.
+      ScreenType.home || ScreenType.other => JetsRouterDelegate().user.isAdmin
+          ? widget.screenConfig.adminMenuEntries
+          : widget.screenConfig.menuEntries,
+      // All workspace IDE screens, i.e. every screen carrying workspace content
+      // in the left menu tree.
+      ScreenType.workspace => JetsRouterDelegate().workspaceMenuState,
+    };
     // print("*** BUILDING BaseScreen");
     return Scaffold(
         appBar: appBar(

--- a/jetsclient/lib/utils/constants.dart
+++ b/jetsclient/lib/utils/constants.dart
@@ -106,11 +106,7 @@ ButtonStyle? buttonStyle(ActionStyle style, ThemeData td) {
         backgroundColor: td.colorScheme.primaryContainer,
         textStyle: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
       ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0));
-
-    default: // primary
-      print("*** UNKNOWN ActionStyle: $style");
   }
-  return null;
 }
 
 /// Screen ID Keys

--- a/jetsclient/pubspec.yaml
+++ b/jetsclient/pubspec.yaml
@@ -17,8 +17,13 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 version: 1.0.0+1
 
+# The lower bound also sets the language version this package's own sources are
+# compiled at, so it is not merely a floor on the toolchain. It said
+# '>=2.18.0-161.0.dev <3.0.0' long after the package required Dart 3 — the
+# resolved dependencies in pubspec.lock need '>=3.12.0 <4.0.0' — which left the
+# sources on 2.18 semantics and Dart 3 language features unavailable.
 environment:
-  sdk: '>=2.18.0-161.0.dev <3.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/jetsclient/test/form_field_key_test.dart
+++ b/jetsclient/test/form_field_key_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jetsclient/components/jets_form_state.dart';
+import 'package:jetsclient/models/form_config.dart';
+import 'package:jetsclient/routes/jets_route_data.dart';
+
+/// [FormFieldConfig.makeFormField] used to stamp every widget with a
+/// `UniqueKey()`, which gave each field a fresh identity on every build. Flutter
+/// then discarded the element and its State on each rebuild, so a field could
+/// not hold anything across one — the reason a text field's controller had to be
+/// re-seeded, and why an in-progress edit could be thrown away by an unrelated
+/// notify.
+///
+/// The key is now derived from the field's identity, `group::key`, which is
+/// stable across builds and distinct between fields. These tests pin both
+/// halves of that: stability, and the absence of collisions that would throw a
+/// duplicate-key error inside one form.
+FormConfig _formConfig() => FormConfig(
+      key: 'testForm',
+      actions: const [],
+      formValidatorDelegate: (p0, p1, p2, p3) => null,
+      formActionsDelegate: doNothingAction,
+    );
+
+Key? _keyOf(FormFieldConfig config, JetsFormState formState) =>
+    config
+        .makeFormField(
+          screenPath: const JetsRouteData('/test'),
+          formConfig: _formConfig(),
+          formState: formState,
+        )
+        .key;
+
+FormInputFieldConfig _input({required String key, int group = 0}) =>
+    FormInputFieldConfig(
+      key: key,
+      group: group,
+      label: key,
+      hint: key,
+      autofocus: false,
+      textRestriction: TextRestriction.none,
+      maxLength: 100,
+    );
+
+void main() {
+  late JetsFormState formState;
+
+  setUp(() {
+    formState = JetsFormState(initialGroupCount: 2);
+    formState.formKey = GlobalKey<FormState>();
+  });
+
+  test('the same field config yields the same key on every build', () {
+    final config = _input(key: 'inputColumn');
+    expect(_keyOf(config, formState), _keyOf(config, formState));
+  });
+
+  test('two configs describing the same field agree on the key', () {
+    expect(_keyOf(_input(key: 'inputColumn'), formState),
+        _keyOf(_input(key: 'inputColumn'), formState));
+  });
+
+  test('different fields in the same group get different keys', () {
+    expect(_keyOf(_input(key: 'inputColumn'), formState),
+        isNot(_keyOf(_input(key: 'functionName'), formState)));
+  });
+
+  test('the same field in different groups gets different keys', () {
+    // This is the dynamic-row case: a row builder emits the same field keys for
+    // every row and separates them by group, so group must take part in the
+    // identity or every row would collide.
+    expect(_keyOf(_input(key: 'inputColumn', group: 0), formState),
+        isNot(_keyOf(_input(key: 'inputColumn', group: 1), formState)));
+  });
+
+  testWidgets('a row of distinct fields builds without a duplicate-key error',
+      (WidgetTester tester) async {
+    final fields = [
+      _input(key: 'inputColumn'),
+      _input(key: 'functionName'),
+      _input(key: 'functionArgument'),
+    ];
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Form(
+          key: formState.formKey,
+          child: Row(
+            children: fields
+                .map((f) => Flexible(
+                      flex: f.flex,
+                      fit: FlexFit.tight,
+                      child: f.makeFormField(
+                        screenPath: const JetsRouteData('/test'),
+                        formConfig: _formConfig(),
+                        formState: formState,
+                      ),
+                    ))
+                .toList(),
+          ),
+        ),
+      ),
+    ));
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/jetsclient/test/jets_route_data_test.dart
+++ b/jetsclient/test/jets_route_data_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jetsclient/routes/jets_route_data.dart';
+import 'package:jetsclient/routes/jets_routes_app.dart';
+
+/// [JetsRouteData.authRequired] decides whether a route may be reached without
+/// a session, so widening it by accident is a security bug rather than a
+/// cosmetic one. It used to be a substring test —
+/// `path.contains('login') || path.contains('register')` — which made any
+/// route public as soon as its path happened to contain either word. These
+/// tests pin the exact-match behaviour that replaced it.
+void main() {
+  group('authRequired', () {
+    test('the two public routes are reachable without a session', () {
+      expect(const JetsRouteData(loginPath).authRequired, isFalse);
+      expect(const JetsRouteData(registerPath).authRequired, isFalse);
+    });
+
+    test('ordinary routes require a session', () {
+      for (final path in [
+        homePath,
+        workspaceRegistryPath,
+        userAdminPath,
+        queryToolPath,
+        inferServerAdminPath,
+        pageNotFoundPath,
+      ]) {
+        expect(JetsRouteData(path).authRequired, isTrue,
+            reason: '$path must not be public');
+      }
+    });
+
+    test('a path merely containing "login" or "register" is not public', () {
+      // These are the cases the old substring test got wrong. None is a real
+      // route today; the point is that adding one later must not silently
+      // open a hole.
+      for (final path in [
+        '/auditLoginHistory',
+        '/loginAttempts',
+        '/registerFileKeyUF',
+        '/clientRegistry/register/details',
+      ]) {
+        expect(JetsRouteData(path).authRequired, isTrue,
+            reason: '$path must not be public');
+      }
+    });
+
+    test('the public set is exactly the login and register routes', () {
+      expect(JetsRouteData.publicPaths, {loginPath, registerPath});
+    });
+  });
+}


### PR DESCRIPTION
Phase 0 of the jetsclient UI assessment: the fixes worth making regardless of whether the UI is later ported or stays on Flutter. Three commits, each independently reviewable.

## 1. `authRequired` was a substring test

```dart
!(path.contains('login') || path.contains('register'))
```

It is correct for the routes that exist today — which is what makes this latent rather than live. But nothing stops a future route from containing either word, and the failure mode when one does is that the route becomes publicly reachable with no error, no warning, and nothing in the diff that looks like an auth change.

The substring test also buys nothing, because `path` is never a URL. `jetsRoutesParser` matches a template from `jetsRoutesMap`, lifts the `:` segments into `params`, and returns the template verbatim — or falls through to `pageNotFoundPath`. The value tested is therefore always one of a closed set of constants, so an exact match is both sufficient and unwidenable:

```dart
static const publicPaths = <String>{loginPath, registerPath};
bool get authRequired => !publicPaths.contains(path);
```

Built from the route constants rather than string literals, so it cannot drift from the route table.

## 2. Form fields were rebuilt from scratch on every build

`makeFormField` stamped every widget with `UniqueKey()`. A `UniqueKey` is unequal to itself across builds, so each rebuild gave every field a new identity and Flutter discarded the element and its `State`. A field could not hold anything across a rebuild: the text controller had to be re-seeded each time, and an edit in progress could be discarded by a notify unrelated to the field being typed into.

The key is now `'$group::$key'`. That pair is the right identity because it is already the one the rest of the form uses — `JetsFormState` is keyed by group then widget key, and the dynamic row builders emit identical field keys per row separated by `group`, which is why `FormFieldConfig.group` is non-final and reassigned positionally. Two fields colliding under this key would already be sharing a form-state slot.

## 3. Stale `mapMenuEntry` comment and `pubspec.yaml` constraint

The comment claimed a 120K cap while the code tested `250000`, in two places. The threshold is now the named `workspaceFileEditorSizeLimit`, carrying the reason: the editor is a single Flutter text field, and Flutter lays a text field's whole document out per frame rather than virtualising by line, so cost tracks file size rather than the visible window. That is also why `mapMenuEntry` drops the route *and* the menu action — an oversized file's entry is inert by construction rather than slow.

The sdk constraint said `>=2.18.0-161.0.dev <3.0.0`. That is not just a stale floor: **the lower bound sets the language version this package's sources compile at**, so the app was being built with Dart 2.18 semantics on a Dart 3.12.2 SDK. `pubspec.lock` has needed `>=3.12.0 <4.0.0` for some time. Now corrected.

## 4. Four unreachable switch defaults

Correcting the language version made the analyser see this code as Dart 3 for the first time, and it found four `default:` clauses that cannot run because the enum is already covered in full. Each was written as the house "this is misconfigured" branch, but that idiom earns its place only over a *string*, where an unknown key can genuinely arrive; over a closed enum it is dead the day it is written.

Removing them is not just tidying, because Dart 3 then checks exhaustiveness. Verified rather than assumed — uncommenting `Operator.lessThan`, one of four operators sitting commented out in that enum, now fails:

```
error • The type 'Operator' isn't exhaustively matched by the switch cases
        since it doesn't match the pattern 'Operator.lessThan'
        • non_exhaustive_switch_statement
```

Before this branch the same change compiled clean and the new operator silently evaluated to `false` — precisely the bug the default created while appearing to prevent one.

`buttonStyle` also loses its trailing `return null`, reachable only via the dead branch. `base_screen` becomes a switch *expression*: its `menuEntries` was pre-seeded with `[]`, so deleting the default alone would have bought nothing — a later `ScreenType` would still compile and render an empty left menu silently. As an expression it is `final`, initialised once, and a new `ScreenType` is a compile error.

## Verification

| Check | Result |
|---|---|
| `flutter analyze` | **127 issues** — down from the 129 this started at |
| `flutter build web --release` | succeeded |
| `flutter test --platform chrome` | **11 passed** (9 new, 2 existing) |

The analyze count moves 129 → 133 → 127: correcting the language version surfaced the 4 dead defaults, and removing them also removed 2 `avoid_print` infos that lived inside those branches. The one remaining warning, an unused local in `user_flow_actions.dart`, predates this work and is untouched.

`test/widget_test.dart` still fails. It is the stock `flutter create` counter test asserting against a UI this app has never had; confirmed to fail identically on the unmodified parent commit.

### New tests

- `test/jets_route_data_test.dart` — pins the exact-match behaviour, including the four shapes of path the substring test got wrong.
- `test/form_field_key_test.dart` — pins both halves of the key contract (stable across builds, distinct between fields and between groups) and builds a row of fields to show the keys do not collide.

## One thing to check before merging

`JetsTextFormField` seeds its controller in `initState` and, without `syncWithFormState: true`, never re-reads form state. Under `UniqueKey` the field was rebuilt from scratch on every parent build, so **a programmatic write sometimes appeared anyway, by accident**. With a stable key the element survives and that accident stops.

That is the documented contract working as intended, but not necessarily what every screen has been relying on. Any field written by something other than the user, and not already opted in, may now need `syncWithFormState: true`. This is invisible to both the analyser and the tests and wants a pass over the screens with the app running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
