### PR TITLE
Add the CodeMirror Workspace IDE, served at /ide/

### DIFF
--- a/jets/apiserver/main.go
+++ b/jets/apiserver/main.go
@@ -68,6 +68,7 @@ var dsn = flag.String("dsn", "", "primary database connection string (required u
 var tokenExpiration = flag.Int("tokenExpiration", 60, "Token expiration in min, must be more than 5 min (default 60)")
 var unitTestDir = flag.String("unitTestDir", "", "Unit Test Data directory, will be prefixed by ${WORKSPACES_HOME}/${WORKSPACE} if defined and unitTestDir starts with '.' e.g. ./data/test_data (dev mode only)")
 var uiWebDir = flag.String("WEB_APP_DEPLOYMENT_DIR", "/usr/local/lib/web", "UI static web app directory")
+var ideWebDir = flag.String("IDE_APP_DEPLOYMENT_DIR", "/usr/local/lib/ide", "Workspace IDE (jetsclient_ide) static web app directory")
 var adminEmail = flag.String("adminEmail", "admin", "Admin email, may not be an actual email (default is admin)")
 var awsAdminPwdSecret = flag.String("awsAdminPwdSecret", "", "aws secret with Admin password as string (aws integration) (required unless -adminPwd is provided)")
 var adminPwd = flag.String("adminPwd", "", "Admin password (required unless -awsAdminPwdSecret is provided)")
@@ -89,6 +90,10 @@ func main() {
 	webAppDirEnv := os.Getenv("WEB_APP_DEPLOYMENT_DIR")
 	if webAppDirEnv != "" {
 		*uiWebDir = webAppDirEnv
+	}
+	ideAppDirEnv := os.Getenv("IDE_APP_DEPLOYMENT_DIR")
+	if ideAppDirEnv != "" {
+		*ideWebDir = ideAppDirEnv
 	}
 	if *adminEmail == "" {
 		*adminEmail = os.Getenv("JETS_ADMIN_EMAIL")

--- a/jets/apiserver/server.go
+++ b/jets/apiserver/server.go
@@ -431,6 +431,13 @@ func listenAndServe() error {
 	// Home Route
 	// server.Router.HandleFunc("/", audit(jsonh(server.Home))).Methods("GET")
 
+	// Serve the Workspace IDE (jetsclient_ide) — one handler over a prefix rather
+	// than a route per asset, because vite emits content-hashed file names that
+	// cannot be enumerated here. See static_ide.go.
+	server.Router.PathPrefix(ideAssetPrefix).
+		Handler(ideHandler(ideAssetPrefix, *ideWebDir)).
+		Methods("GET")
+
 	// Serve the jetsclient app
 	fs := http.FileServer(http.Dir(*uiWebDir))
 	server.Router.Handle("/", fs).Methods("GET")

--- a/jets/apiserver/static_ide.go
+++ b/jets/apiserver/static_ide.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// Serving for the Workspace IDE bundle (jetsclient_ide/).
+//
+// One handler over a path prefix, rather than the per-asset route list the
+// Flutter bundle uses above it in server.go. That is not a style preference: vite
+// emits content-hashed file names (index-DlXT-v6f.js), so the set of assets
+// changes on every build and cannot be enumerated in Go at all. The hashing is
+// also what makes the cache policy below safe.
+//
+// The Flutter routes are deliberately left alone. They work, they are explicit,
+// and consolidating them means moving the static registration after the api
+// routes so a catch-all cannot shadow /login — a change worth making on its own
+// when the Flutter app is retired, not as a rider on this one.
+
+// ideAssetPrefix is the url space the IDE owns. Everything under it is either a
+// bundled asset or a client-side route.
+const ideAssetPrefix = "/ide/"
+
+// ideHandler serves a single-page app from dir.
+//
+// Requests resolve to a file when one exists; anything else falls back to
+// index.html so client-side routes survive a reload. The fallback is what makes
+// this a SPA handler rather than a file server, and it is why the api routes must
+// never live under this prefix.
+func ideHandler(prefix, dir string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rel := strings.TrimPrefix(r.URL.Path, prefix)
+		// path.Clean("/"+rel) collapses any ".." before it can escape dir. Joining
+		// the *cleaned absolute* form is what makes traversal impossible; cleaning
+		// after the join would be too late.
+		clean := path.Clean("/" + rel)
+		target := filepath.Join(dir, filepath.FromSlash(clean))
+
+		if info, err := os.Stat(target); err == nil && !info.IsDir() {
+			// Hashed asset names change whenever the content does, so they can be
+			// cached hard. index.html carries no hash and must not be.
+			if strings.HasPrefix(clean, "/assets/") {
+				w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+			} else {
+				w.Header().Set("Cache-Control", "no-cache")
+			}
+			http.ServeFile(w, r, target)
+			return
+		}
+
+		// A missing asset must 404 rather than silently returning the html shell:
+		// handing index.html to a request for a .js file produces a console error
+		// about an unexpected '<' that says nothing about the real cause.
+		if strings.HasPrefix(clean, "/assets/") {
+			http.NotFound(w, r)
+			return
+		}
+
+		index := filepath.Join(dir, "index.html")
+		if _, err := os.Stat(index); err != nil {
+			http.Error(w, "Workspace IDE is not deployed on this server", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Cache-Control", "no-cache")
+		http.ServeFile(w, r, index)
+	})
+}

--- a/jets/apiserver/static_ide_test.go
+++ b/jets/apiserver/static_ide_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// buildIdeDir lays out a directory shaped like a vite build.
+func buildIdeDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"index.html":              "<!doctype html><div id=root></div>",
+		"assets/index-abc123.js":  "console.log(1)",
+		"assets/index-abc123.css": ".a{}",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(name)), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func get(t *testing.T, h http.Handler, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+	return rec
+}
+
+func TestIdeHandlerServesHashedAssets(t *testing.T) {
+	h := ideHandler(ideAssetPrefix, buildIdeDir(t))
+
+	res := get(t, h, "/ide/assets/index-abc123.js")
+	if res.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", res.Code)
+	}
+	if body := res.Body.String(); body != "console.log(1)" {
+		t.Errorf("unexpected body %q", body)
+	}
+	// Hashed names change with content, so they are safe to cache indefinitely.
+	if cc := res.Header().Get("Cache-Control"); cc != "public, max-age=31536000, immutable" {
+		t.Errorf("asset Cache-Control = %q", cc)
+	}
+}
+
+func TestIdeHandlerServesIndexAtRoot(t *testing.T) {
+	h := ideHandler(ideAssetPrefix, buildIdeDir(t))
+	res := get(t, h, "/ide/")
+	if res.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", res.Code)
+	}
+	if cc := res.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("index Cache-Control = %q, want no-cache", cc)
+	}
+}
+
+func TestIdeHandlerFallsBackToIndexForClientRoutes(t *testing.T) {
+	h := ideHandler(ideAssetPrefix, buildIdeDir(t))
+	// A deep client-side route must survive a reload rather than 404.
+	res := get(t, h, "/ide/workspace/cedargate_ws/jet_rules/main.jr")
+	if res.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", res.Code)
+	}
+	if body := res.Body.String(); body != "<!doctype html><div id=root></div>" {
+		t.Errorf("expected the html shell, got %q", body)
+	}
+}
+
+func TestIdeHandlerDoesNotFallBackForMissingAssets(t *testing.T) {
+	h := ideHandler(ideAssetPrefix, buildIdeDir(t))
+	// Returning index.html here would surface as "unexpected token '<'" in the
+	// browser, which points nowhere near the real problem.
+	res := get(t, h, "/ide/assets/index-deadbeef.js")
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404", res.Code)
+	}
+}
+
+func TestIdeHandlerRejectsTraversal(t *testing.T) {
+	dir := buildIdeDir(t)
+	secret := filepath.Join(filepath.Dir(dir), "secret.txt")
+	if err := os.WriteFile(secret, []byte("do not serve"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := ideHandler(ideAssetPrefix, dir)
+
+	for _, target := range []string{
+		"/ide/../secret.txt",
+		"/ide/assets/../../secret.txt",
+		"/ide/..%2f..%2fsecret.txt",
+	} {
+		res := get(t, h, target)
+		if body := res.Body.String(); body == "do not serve" {
+			t.Errorf("%s escaped the bundle directory", target)
+		}
+	}
+}
+
+// TestIdeHandlerServesTheRealBundle checks the one thing the synthetic fixtures
+// above cannot: that the asset paths vite actually emits line up with the prefix
+// this handler actually strips. Skipped unless the bundle has been built, since
+// jetsclient_ide/dist is a build artifact and is not committed.
+func TestIdeHandlerServesTheRealBundle(t *testing.T) {
+	dir, err := filepath.Abs(filepath.Join("..", "..", "jetsclient_ide", "dist"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	index, err := os.ReadFile(filepath.Join(dir, "index.html"))
+	if err != nil {
+		t.Skip("jetsclient_ide/dist not built; run `npm run build` in jetsclient_ide")
+	}
+	h := ideHandler(ideAssetPrefix, dir)
+
+	if res := get(t, h, "/ide/"); res.Code != http.StatusOK {
+		t.Fatalf("serving index: got %d, want 200", res.Code)
+	}
+
+	// Pull the emitted asset urls straight out of the html and fetch each one.
+	refs := regexp.MustCompile(`(?:src|href)="([^"]+)"`).FindAllStringSubmatch(string(index), -1)
+	checked := 0
+	for _, m := range refs {
+		ref := m[1]
+		if !strings.HasPrefix(ref, ideAssetPrefix) {
+			t.Errorf("asset %q is not under %q — vite `base` and the Go prefix disagree", ref, ideAssetPrefix)
+			continue
+		}
+		if res := get(t, h, ref); res.Code != http.StatusOK {
+			t.Errorf("asset %q: got %d, want 200", ref, res.Code)
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Error("index.html referenced no assets; the build looks wrong")
+	}
+}
+
+func TestIdeHandlerReportsMissingDeployment(t *testing.T) {
+	// An apiserver built without the IDE bundle should say so rather than 500.
+	h := ideHandler(ideAssetPrefix, filepath.Join(t.TempDir(), "absent"))
+	res := get(t, h, "/ide/")
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404", res.Code)
+	}
+}

--- a/jets/apiserver/static_routes_test.go
+++ b/jets/apiserver/static_routes_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+// The Workspace IDE is registered as a PathPrefix ahead of the Flutter routes and
+// ahead of the api routes, which puts it in a position to shadow either of them.
+// gorilla/mux matches routes in registration order and PathPrefix matches on a
+// prefix rather than the whole path, so "does the new route steal traffic from an
+// old one" is a question about ordering that only a router can answer — reading
+// the handler in isolation cannot.
+//
+// This mirrors the registration order in server.go rather than calling it, since
+// the real function needs a database. If that order changes, change it here too;
+// a divergence makes this test worse than useless.
+func routerLikeServer(t *testing.T, uiDir, ideDir string) *mux.Router {
+	t.Helper()
+	r := mux.NewRouter()
+
+	r.PathPrefix(ideAssetPrefix).
+		Handler(ideHandler(ideAssetPrefix, ideDir)).
+		Methods("GET")
+
+	fs := http.FileServer(http.Dir(uiDir))
+	r.Handle("/", fs).Methods("GET")
+	r.Handle("/flutter.js", fs).Methods("GET")
+	r.Handle("/main.dart.js", fs).Methods("GET")
+
+	// A stand-in for the api routes, which are registered after the static ones.
+	r.HandleFunc("/login", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("login-handler"))
+	}).Methods("POST")
+
+	return r
+}
+
+// flutterDir lays out a directory shaped like `flutter build web` output.
+func flutterDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range map[string]string{
+		"index.html":   "<html>flutter shell</html>",
+		"flutter.js":   "// flutter loader",
+		"main.dart.js": "// compiled app",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestIdePrefixDoesNotShadowTheFlutterApp(t *testing.T) {
+	r := routerLikeServer(t, flutterDir(t), buildIdeDir(t))
+
+	// "/" is what the browser asks for when the user opens the app, including
+	// when the url carries a "#/login" fragment — the fragment never reaches the
+	// server, so a 404 here is what a user reports as "cannot get to the login
+	// page".
+	res := get(t, r, "/")
+	if res.Code != http.StatusOK {
+		t.Fatalf("GET /: got %d, want 200", res.Code)
+	}
+	if body := res.Body.String(); body != "<html>flutter shell</html>" {
+		t.Errorf("GET / served %q, want the Flutter shell", body)
+	}
+
+	for _, asset := range []string{"/flutter.js", "/main.dart.js"} {
+		if res := get(t, r, asset); res.Code != http.StatusOK {
+			t.Errorf("GET %s: got %d, want 200", asset, res.Code)
+		}
+	}
+}
+
+func TestIdePrefixDoesNotShadowTheApiRoutes(t *testing.T) {
+	r := routerLikeServer(t, flutterDir(t), buildIdeDir(t))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/login", nil))
+	if rec.Code != http.StatusOK || rec.Body.String() != "login-handler" {
+		t.Fatalf("POST /login: got %d %q, want 200 login-handler", rec.Code, rec.Body.String())
+	}
+}
+
+func TestIdeRoutesStillResolveAlongsideTheFlutterApp(t *testing.T) {
+	r := routerLikeServer(t, flutterDir(t), buildIdeDir(t))
+
+	if res := get(t, r, "/ide/"); res.Code != http.StatusOK {
+		t.Errorf("GET /ide/: got %d, want 200", res.Code)
+	}
+	if res := get(t, r, "/ide/assets/index-abc123.js"); res.Code != http.StatusOK {
+		t.Errorf("GET /ide asset: got %d, want 200", res.Code)
+	}
+}
+
+// TestFlutterRootIs404WithoutABundle reproduces the reported failure and pins its
+// real cause, which is not routing. WEB_APP_DEPLOYMENT_DIR defaults to
+// /usr/local/lib/web; on a development machine that path does not exist, so the
+// FileServer behind "/" has nothing to serve and every Flutter url 404s while
+// /ide/ keeps working. The fix is to point the flag at `flutter build web`
+// output, not to change any route.
+func TestFlutterRootIs404WithoutABundle(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "not-deployed")
+	r := routerLikeServer(t, missing, buildIdeDir(t))
+
+	if res := get(t, r, "/"); res.Code != http.StatusNotFound {
+		t.Fatalf("GET / with no bundle: got %d, want 404", res.Code)
+	}
+	// The IDE is unaffected, which is exactly the asymmetry that makes this look
+	// like the IDE broke the Flutter app.
+	if res := get(t, r, "/ide/"); res.Code != http.StatusOK {
+		t.Fatalf("GET /ide/ with no Flutter bundle: got %d, want 200", res.Code)
+	}
+}

--- a/jetsclient/lib/modules/workspace_ide/screen_config.dart
+++ b/jetsclient/lib/modules/workspace_ide/screen_config.dart
@@ -1,6 +1,7 @@
 import 'package:jetsclient/routes/jets_routes_app.dart';
 import 'package:jetsclient/utils/constants.dart';
 import 'package:jetsclient/models/screen_config.dart';
+import 'package:jetsclient/modules/workspace_ide/screen_delegates_helpers.dart';
 
 //*TODO Take path params from current Navigator provider (current page)
 final List<MenuEntry> workspaceRegistryMenuEntries = [
@@ -16,6 +17,13 @@ final List<MenuEntry> workspaceRegistryMenuEntries = [
       key: 'queryTool',
       label: 'Query Tool',
       routePath: queryToolPath),
+  // The CodeMirror editor, served by this apiserver at /ide/. It opens in a new
+  // tab and has no routePath, so it never joins this app's page stack.
+  MenuEntry(
+      key: 'codeEditor',
+      label: 'Code Editor ↗',
+      capability: 'workspace_ide',
+      menuAction: openWorkspaceIdeApp),
   // Disabled rather than hidden without the capability, as base_screen does for every
   // menu entry. The api endpoint enforces the same capability independently.
   MenuEntry(

--- a/jetsclient/lib/modules/workspace_ide/screen_delegates_helpers.dart
+++ b/jetsclient/lib/modules/workspace_ide/screen_delegates_helpers.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:web/web.dart' as web;
 import 'package:jetsclient/http_client.dart';
 import 'package:jetsclient/routes/jets_route_data.dart';
 import 'package:jetsclient/routes/jets_router_delegate.dart';
@@ -73,6 +74,26 @@ Future<String?> openWorkspaceActions(
     JetsSpinnerOverlay.of(context).hide();
   }
   return null;
+}
+
+/// Opens the CodeMirror Workspace IDE (jetsclient_ide) in a new tab.
+///
+/// That app is a separate bundle served by this same apiserver under /ide/, so
+/// the url is resolved against the api origin rather than against the browser's,
+/// which differ under `flutter run`.
+///
+/// It opens in a new tab rather than an iframe because it owns its own routing
+/// and its own editor keybindings, both of which an embedded frame would fight.
+/// One consequence worth knowing: it holds its token in memory and does not share
+/// this app's session, so the user signs in once more there.
+Future<int> openWorkspaceIdeApp(
+    BuildContext context, MenuEntry menuEntry, State<StatefulWidget> state) async {
+  // main() always sets serverAdd, but falling back to the relative path is the
+  // right answer anyway: in production the IDE is served from this same origin.
+  final base = HttpClientSingleton().serverAdd;
+  final url = base == null ? '/ide/' : base.resolve('/ide/').toString();
+  web.window.open(url, '_blank');
+  return 200;
 }
 
 /// Files of this size or larger are not opened in the Workspace IDE.

--- a/jetsclient_ide/.gitignore
+++ b/jetsclient_ide/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.local
+.vite/

--- a/jetsclient_ide/README.md
+++ b/jetsclient_ide/README.md
@@ -71,13 +71,14 @@ does not know which one it is in.
 Point `IDE_APP_DEPLOYMENT_DIR` at the built bundle:
 
 ```bash
-npm run build
+npm run build                     # the IDE bundle
+cd ../jetsclient && flutter build web --release && cd ..   # the Flutter bundle
 
-cd ..
 go build -o /tmp/apiserver ./jets/apiserver
 
 WORKSPACES_HOME=/home/michel/projects/repos/workspaces \
 WORKSPACE=jets_ws \
+WEB_APP_DEPLOYMENT_DIR=$PWD/jetsclient/build/web \
 IDE_APP_DEPLOYMENT_DIR=$PWD/jetsclient_ide/dist \
 JETS_DSN='postgresql://...' \
 API_SECRET='...' \
@@ -86,6 +87,16 @@ API_SECRET='...' \
 
 Then open <http://localhost:8080/ide/>. `-usingSshTunnel` is what puts the server
 on `:8080` without TLS; without it the server listens on `:8443`.
+
+**Set `WEB_APP_DEPLOYMENT_DIR` even if you only care about the IDE.** It defaults
+to `/usr/local/lib/web`, which exists in the container image and on no
+development machine, and the `/` route is an `http.FileServer` over it. Leave it
+unset and every Flutter url 404s — including `/#/login`, because the fragment
+never reaches the server and the browser is really asking for `/` — while `/ide/`
+carries on working from its own directory. The asymmetry makes it look like the
+IDE broke the Flutter app; it did not, and
+`TestIdePrefixDoesNotShadowTheFlutterApp` in `jets/apiserver` exists to keep that
+answerable without guessing.
 
 The flag is `-IDE_APP_DEPLOYMENT_DIR`, and the environment variable of the same
 name overrides it — the same arrangement `WEB_APP_DEPLOYMENT_DIR` uses for the

--- a/jetsclient_ide/README.md
+++ b/jetsclient_ide/README.md
@@ -1,0 +1,166 @@
+# jetsclient_ide
+
+The JetStore Workspace IDE: a React + TypeScript single-page app built around
+[CodeMirror 6](https://codemirror.net/), served by the Go apiserver at `/ide/`.
+
+It exists because the Flutter client's file editor is a single `TextFormField`.
+Flutter lays a text field's whole document out on every frame rather than
+virtualising by line, so cost grows with the size of the file instead of with the
+part of it on screen — which is why `mapMenuEntry` refuses to open anything at or
+above 250,000 bytes, and why three real `.jr` files in the workspace corpus, the
+largest 1.18 MB, cannot be opened in the IDE at all. CodeMirror virtualises by
+viewport, so **this app has no size limit**; `src/api/workspace.test.ts` pins that
+with a 1.2 MB load.
+
+This is the first stage of the port described in the UI assessment. It shares the
+Go apiserver, the `/dataTable` endpoints, the JWT session and the `workspace_ide`
+capability with the Flutter app, and runs alongside it rather than replacing it.
+
+## Layout
+
+```
+src/
+  api/client.ts      HttpClient — bearer auth, per-response token refresh, 401 handling
+  api/workspace.ts   typed wrappers over the workspace_* /dataTable actions
+  editor/jetrules.ts CodeMirror mode for the JetRules DSL
+  editor/language.ts file extension -> language
+  editor/theme.ts    editor theme, driven by the same CSS variables as the shell
+  editor/Editor.tsx  the CodeMirror view, wrapped for React
+  components/        file tree, login
+  App.tsx            shell: workspace picker, tabs, save
+```
+
+## The server contract
+
+Everything here mirrors Go source rather than a written spec, so when the server
+changes, these are the things that break:
+
+| This app | Server |
+|---|---|
+| `Authorization: Bearer <token>` | `ExtractToken`, `jets/user/token.go` |
+| reads `token` from **every** response | `authh` mints a fresh one per request, `jets/apiserver/server.go` |
+| `workspace_query_structure` | returns `{result_type, result_data}` of `wsfile.WorkspaceNode` |
+| `get_workspace_file_content` / `save_workspace_file_content` | `jets/datatable/workspace_data_table_action.go` |
+| `file_name` passed back **exactly as received** | the server url-escapes it when building the tree and unescapes it on read |
+| local JSON check before save | `SaveWorkspaceFileContent` refuses a `.json` file that will not parse |
+
+The refresh-per-response behaviour is the one most easily missed: a client that
+does not read `token` out of each body will present a stale one and start getting
+401s. The token is held in memory only — never `localStorage` — so a reload costs
+one sign-in.
+
+## Build
+
+```bash
+npm install
+npm run build       # tsc --noEmit && vite build  ->  dist/
+npm test            # vitest
+npm run typecheck
+```
+
+`dist/` is git-ignored. `npm run build` is the real check; `npm test` covers the
+API client, the workspace wrappers, the language picker and the JetRules mode.
+
+## Running it against a local apiserver
+
+Two ways. Both talk to the same endpoints on the same origin, so the client code
+does not know which one it is in.
+
+### Served by the apiserver (what production does)
+
+Point `IDE_APP_DEPLOYMENT_DIR` at the built bundle:
+
+```bash
+npm run build
+
+cd ..
+go build -o /tmp/apiserver ./jets/apiserver
+
+WORKSPACES_HOME=/home/michel/projects/repos/workspaces \
+WORKSPACE=jets_ws \
+IDE_APP_DEPLOYMENT_DIR=$PWD/jetsclient_ide/dist \
+JETS_DSN='postgresql://...' \
+API_SECRET='...' \
+/tmp/apiserver -usingSshTunnel
+```
+
+Then open <http://localhost:8080/ide/>. `-usingSshTunnel` is what puts the server
+on `:8080` without TLS; without it the server listens on `:8443`.
+
+The flag is `-IDE_APP_DEPLOYMENT_DIR`, and the environment variable of the same
+name overrides it — the same arrangement `WEB_APP_DEPLOYMENT_DIR` uses for the
+Flutter bundle. If it points nowhere, `/ide/` answers 404 with a plain message
+rather than failing obscurely, so an apiserver built without the bundle still
+starts.
+
+### Vite dev server (hot reload)
+
+```bash
+npm run dev                                     # apiserver on :8080
+JETS_API_ORIGIN=https://localhost:8443 npm run dev   # apiserver on :8443
+```
+
+Serves on <http://localhost:5173/ide/> and proxies `/dataTable`, `/login` and the
+other endpoints to the apiserver, so there is no CORS involved and the app still
+sees a same-origin path. The proxy sets `secure: false` for the `:8443` case,
+whose certificate is self-signed.
+
+## Serving
+
+`jets/apiserver/static_ide.go` serves the bundle under `/ide/` with **one**
+`PathPrefix` handler, not the route-per-asset list the Flutter bundle uses. That
+is not tidiness: vite emits content-hashed file names, so the set of assets
+changes on every build and cannot be enumerated in Go. The hashing is also what
+makes the cache policy safe — `/ide/assets/*` is immutable for a year,
+`index.html` is `no-cache`.
+
+Anything under `/ide/` that is not a file falls back to `index.html`, so
+client-side routes survive a reload. A *missing* asset 404s instead, because
+handing back the html shell surfaces in the browser as "unexpected token '<'",
+which points nowhere near the real cause.
+
+The Flutter bundle's ~50 explicit asset routes are deliberately untouched. They
+work, and consolidating them means moving the static registration after the API
+routes so a catch-all cannot shadow `/login` — worth doing when the Flutter app
+is retired, not as a rider on this.
+
+## The JetRules mode
+
+`src/editor/jetrules.ts` is a `StreamLanguage` ported from
+`tools/vscode-jetrule/syntaxes/jetrule.tmLanguage.json`, which stays the reference
+for the language. That grammar is small — fourteen top-level patterns — so porting
+was cheaper than pulling in the TextMate runtime (`vscode-textmate` plus an
+Oniguruma wasm build) purely to reuse it. **Keep the two in step:** something the
+VS Code extension highlights and this does not is a bug in the mode.
+
+A stream tokeniser, not a Lezer grammar, because highlighting is all this needs
+today. Folding by rule, structural selection and go-to-definition all want a real
+tree; that is the point to invest in Lezer, and this cannot give them one.
+
+`.jr.sql` is checked before `.jr` and reads as SQL — the Go visitor serves both
+from the same directories, and the wrong order sends every `.jr.sql` down the
+JetRules branch.
+
+## Getting here from the Flutter app
+
+The Workspace IDE menu carries a **Code Editor ↗** entry that opens `/ide/` in a
+new tab, gated on `workspace_ide` like the other entries. It has no `routePath`,
+so it never joins the Flutter app's page stack, and it opens in a tab rather than
+an iframe because this app owns its own routing and editor keybindings — both of
+which an embedded frame would fight.
+
+**The session is not shared.** This app holds its token in memory, so opening it
+means signing in once more. That is a real wrinkle and the obvious thing to fix
+next; doing it properly means agreeing where a token may be persisted, which is a
+security decision rather than a coding one.
+
+## What this does not do yet
+
+The beachhead is deliberately narrow. Not here: creating, renaming or deleting
+files; git operations; the workspace-registry screens; the Query Tool; diffing
+against the committed version; the pipeline-config and data-model section forms.
+All of those remain in the Flutter app, which is why the two run side by side.
+
+It has also not yet been run against a live apiserver and database. The wire
+contract above is verified against the Go source and by unit tests that assert
+the exact request shapes, but not by a real session.

--- a/jetsclient_ide/index.html
+++ b/jetsclient_ide/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JetStore Workspace IDE</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/jetsclient_ide/package.json
+++ b/jetsclient_ide/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "jetsclient-ide",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "JetStore Workspace IDE — a CodeMirror 6 editor served by the Go apiserver",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@codemirror/autocomplete": "^6.18.6",
+    "@codemirror/commands": "^6.8.1",
+    "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/lang-sql": "^6.8.0",
+    "@codemirror/language": "^6.11.0",
+    "@codemirror/search": "^6.5.10",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/view": "^6.36.4",
+    "@lezer/highlight": "^1.2.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.2.0",
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.3",
+    "vite": "^6.2.0",
+    "vitest": "^3.0.7"
+  }
+}

--- a/jetsclient_ide/src/App.tsx
+++ b/jetsclient_ide/src/App.tsx
@@ -1,0 +1,314 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ApiClient, SessionExpiredError, type User } from "./api/client";
+import { WorkspaceApi, fileNameOf, type WorkspaceNode, type WorkspaceSummary } from "./api/workspace";
+import { FileTree } from "./components/FileTree";
+import { Login } from "./components/Login";
+import { Editor } from "./editor/Editor";
+import { isServerValidatedJson, languageNameFor } from "./editor/language";
+
+const api = new ApiClient();
+const workspaceApi = new WorkspaceApi(api);
+
+/** The capability the server requires for every workspace action. */
+const WORKSPACE_IDE = "workspace_ide";
+
+interface Tab {
+  fileName: string;
+  label: string;
+  /** Text as last loaded or saved; the dirty check compares against this. */
+  saved: string;
+  current: string;
+  size: number;
+}
+
+type Theme = "light" | "dark";
+
+export default function App() {
+  const [user, setUser] = useState<User | null>(api.currentUser);
+  const [workspaces, setWorkspaces] = useState<WorkspaceSummary[]>([]);
+  const [workspace, setWorkspace] = useState<string>("");
+  const [tree, setTree] = useState<WorkspaceNode[]>([]);
+  const [tabs, setTabs] = useState<Tab[]>([]);
+  const [activeFile, setActiveFile] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [theme, setTheme] = useState<Theme>(
+    () => (localStorage.getItem("jetstore-ide-theme") as Theme | null) ?? "light",
+  );
+
+  useEffect(() => api.subscribe(setUser), []);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("jetstore-ide-theme", theme);
+  }, [theme]);
+
+  const canEdit = api.can(WORKSPACE_IDE);
+  const activeTab = useMemo(
+    () => tabs.find((t) => t.fileName === activeFile) ?? null,
+    [tabs, activeFile],
+  );
+  const dirtyCount = tabs.filter((t) => t.current !== t.saved).length;
+
+  /** Routes every failure to the banner, and a dead session back to the login screen. */
+  const guard = useCallback(async (work: () => Promise<void>) => {
+    try {
+      await work();
+    } catch (err) {
+      if (err instanceof SessionExpiredError) {
+        setTabs([]);
+        setActiveFile(null);
+        setTree([]);
+      }
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  // Warn before discarding unsaved buffers on a reload or tab close.
+  useEffect(() => {
+    if (dirtyCount === 0) return;
+    const onBeforeUnload = (e: BeforeUnloadEvent) => e.preventDefault();
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [dirtyCount]);
+
+  useEffect(() => {
+    if (!user) return;
+    void guard(async () => {
+      const list = await workspaceApi.listWorkspaces();
+      setWorkspaces(list);
+      if (list.length > 0 && workspace === "") setWorkspace(list[0]!.name);
+    });
+    // Only when the session changes; picking a workspace is handled below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
+  useEffect(() => {
+    if (!user || workspace === "") return;
+    setTabs([]);
+    setActiveFile(null);
+    setBusy(true);
+    void guard(async () => {
+      setTree(await workspaceApi.fileTree(workspace));
+    }).finally(() => setBusy(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user, workspace]);
+
+  const openFile = useCallback(
+    (node: WorkspaceNode) => {
+      const fileName = fileNameOf(node);
+      if (!fileName) return;
+      if (tabs.some((t) => t.fileName === fileName)) {
+        setActiveFile(fileName);
+        return;
+      }
+      setBusy(true);
+      setStatus(null);
+      void guard(async () => {
+        const file = await workspaceApi.readFile(workspace, node);
+        setTabs((prev) => [
+          ...prev,
+          {
+            fileName: file.fileName,
+            label: file.label,
+            saved: file.content,
+            current: file.content,
+            size: node.size,
+          },
+        ]);
+        setActiveFile(file.fileName);
+      }).finally(() => setBusy(false));
+    },
+    [guard, tabs, workspace],
+  );
+
+  const closeTab = useCallback(
+    (fileName: string) => {
+      const tab = tabs.find((t) => t.fileName === fileName);
+      if (tab && tab.current !== tab.saved) {
+        const ok = window.confirm(`${tab.label} has unsaved changes. Close it anyway?`);
+        if (!ok) return;
+      }
+      setTabs((prev) => {
+        const next = prev.filter((t) => t.fileName !== fileName);
+        setActiveFile((cur) =>
+          cur === fileName ? (next.length > 0 ? next[next.length - 1]!.fileName : null) : cur,
+        );
+        return next;
+      });
+    },
+    [tabs],
+  );
+
+  const save = useCallback(() => {
+    const tab = tabs.find((t) => t.fileName === activeFile);
+    if (!tab || tab.current === tab.saved || !canEdit) return;
+
+    // The server parses .json before writing, so catch it here and point at the
+    // problem rather than surfacing a bare 400.
+    if (isServerValidatedJson(tab.fileName)) {
+      try {
+        JSON.parse(tab.current);
+      } catch (err) {
+        setError(`${tab.label} is not valid JSON, so the server would reject it: ${
+          err instanceof Error ? err.message : String(err)
+        }`);
+        return;
+      }
+    }
+
+    setBusy(true);
+    setError(null);
+    void guard(async () => {
+      await workspaceApi.saveFile(workspace, tab.fileName, tab.current);
+      setTabs((prev) =>
+        prev.map((t) => (t.fileName === tab.fileName ? { ...t, saved: t.current } : t)),
+      );
+      setStatus(`Saved ${tab.label}`);
+    }).finally(() => setBusy(false));
+  }, [activeFile, canEdit, guard, tabs, workspace]);
+
+  const onChange = useCallback(
+    (value: string) => {
+      setTabs((prev) =>
+        prev.map((t) => (t.fileName === activeFile ? { ...t, current: value } : t)),
+      );
+    },
+    [activeFile],
+  );
+
+  if (!user) {
+    return (
+      <Login
+        version=""
+        onSubmit={async (email, password) => {
+          await api.login(email, password);
+          setError(null);
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="app">
+      <header className="topbar">
+        <span className="brand">JetStore <strong>Workspace IDE</strong></span>
+
+        <label className="ws-picker">
+          <span className="sr-only">Workspace</span>
+          <select value={workspace} onChange={(e) => setWorkspace(e.target.value)}>
+            {workspaces.length === 0 && <option value="">No workspaces</option>}
+            {workspaces.map((w) => (
+              <option key={w.name} value={w.name}>
+                {w.name}
+                {w.branch ? ` (${w.branch})` : ""}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="spacer" />
+
+        {busy && <span className="pill">Working…</span>}
+        {!canEdit && <span className="pill pill-warn">Read only — no {WORKSPACE_IDE}</span>}
+
+        <button
+          type="button"
+          className="btn"
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+          aria-label="Toggle colour theme"
+        >
+          {theme === "dark" ? "Light" : "Dark"}
+        </button>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={save}
+          disabled={!activeTab || activeTab.current === activeTab.saved || !canEdit || busy}
+        >
+          Save
+        </button>
+        <button type="button" className="btn" onClick={() => api.logout()}>
+          Sign out
+        </button>
+      </header>
+
+      {error && (
+        <div className="banner banner-error" role="alert">
+          <span>{error}</span>
+          <button type="button" onClick={() => setError(null)} aria-label="Dismiss">
+            ×
+          </button>
+        </div>
+      )}
+      {status && !error && (
+        <div className="banner banner-ok" role="status">
+          <span>{status}</span>
+          <button type="button" onClick={() => setStatus(null)} aria-label="Dismiss">
+            ×
+          </button>
+        </div>
+      )}
+
+      <div className="body">
+        <aside className="sidebar">
+          <FileTree nodes={tree} activeFile={activeFile} onOpen={openFile} />
+        </aside>
+
+        <main className="main">
+          <div className="tabbar" role="tablist">
+            {tabs.map((t) => (
+              <div
+                key={t.fileName}
+                className={`tab${t.fileName === activeFile ? " is-active" : ""}`}
+                role="tab"
+                aria-selected={t.fileName === activeFile}
+              >
+                <button type="button" className="tab-label" onClick={() => setActiveFile(t.fileName)}>
+                  {t.current !== t.saved && <span className="dot" aria-label="unsaved" />}
+                  {t.label.split("/").pop()}
+                </button>
+                <button
+                  type="button"
+                  className="tab-close"
+                  onClick={() => closeTab(t.fileName)}
+                  aria-label={`Close ${t.label}`}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {activeTab ? (
+            <>
+              <Editor
+                docKey={activeTab.fileName}
+                fileName={activeTab.label}
+                content={activeTab.saved}
+                readOnly={!canEdit}
+                onChange={onChange}
+                onSave={save}
+              />
+              <footer className="statusbar">
+                <span title={activeTab.label}>{activeTab.label}</span>
+                <span className="spacer" />
+                <span>{languageNameFor(activeTab.label)}</span>
+                <span>{activeTab.current.length.toLocaleString()} chars</span>
+                <span>{activeTab.current !== activeTab.saved ? "Modified" : "Saved"}</span>
+              </footer>
+            </>
+          ) : (
+            <div className="empty">
+              <p>Select a file to start editing.</p>
+              <p className="empty-sub">
+                Every file in the workspace opens here, whatever its size.
+              </p>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/jetsclient_ide/src/api/client.test.ts
+++ b/jetsclient_ide/src/api/client.test.ts
@@ -52,7 +52,19 @@ describe("ApiClient", () => {
     expect(api.currentUser?.email).toBe("ada@example.com");
     expect(api.currentUser?.capabilities).toEqual(["workspace_ide"]);
     expect(calls[0]?.url).toBe("/login");
-    expect(calls[0]?.body).toEqual({ email: "ada@example.com", password: "pw" });
+  });
+
+  it("posts the email as user_email, the field the server unmarshals", () => {
+    // Regression: this was `email`, which unmarshals into user.User as an empty
+    // Email — the server then answers "required Email" for a form that plainly
+    // had one, and the audit log records a login for user "". The tag is
+    // `json:"user_email"` in jets/user/user.go, and the Flutter client posts the
+    // same key. Asserting the wire field rather than the argument name is the
+    // whole point of this test.
+    return signedIn([]).then(({ calls }) => {
+      expect(calls[0]?.body).toEqual({ user_email: "ada@example.com", password: "pw" });
+      expect(calls[0]?.body).not.toHaveProperty("email");
+    });
   });
 
   it("rejects a login that returns no token", async () => {

--- a/jetsclient_ide/src/api/client.test.ts
+++ b/jetsclient_ide/src/api/client.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { ApiClient, SessionExpiredError } from "./client";
+
+interface Call {
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+/** A fetch stand-in that records calls and replays queued responses. */
+function stubFetch(queue: Array<{ status: number; body: unknown }>) {
+  const calls: Call[] = [];
+  const impl = (async (url: string, init?: RequestInit) => {
+    calls.push({
+      url: String(url),
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    const next = queue.shift() ?? { status: 200, body: {} };
+    return {
+      ok: next.status >= 200 && next.status < 300,
+      status: next.status,
+      text: async () => (typeof next.body === "string" ? next.body : JSON.stringify(next.body)),
+    } as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+const LOGIN_OK = {
+  status: 200,
+  body: {
+    name: "Ada",
+    user_email: "ada@example.com",
+    is_admin: false,
+    capabilities: ["workspace_ide"],
+    token: "token-1",
+    jetstore_version: "1.2.3",
+  },
+};
+
+async function signedIn(queue: Array<{ status: number; body: unknown }>) {
+  const { impl, calls } = stubFetch([LOGIN_OK, ...queue]);
+  const api = new ApiClient("", impl);
+  await api.login("ada@example.com", "pw");
+  return { api, calls };
+}
+
+describe("ApiClient", () => {
+  it("signs in and exposes the user", async () => {
+    const { api, calls } = await signedIn([]);
+    expect(api.isAuthenticated).toBe(true);
+    expect(api.currentUser?.email).toBe("ada@example.com");
+    expect(api.currentUser?.capabilities).toEqual(["workspace_ide"]);
+    expect(calls[0]?.url).toBe("/login");
+    expect(calls[0]?.body).toEqual({ email: "ada@example.com", password: "pw" });
+  });
+
+  it("rejects a login that returns no token", async () => {
+    const { impl } = stubFetch([{ status: 200, body: { user_email: "a@b.c" } }]);
+    const api = new ApiClient("", impl);
+    await expect(api.login("a@b.c", "pw")).rejects.toThrow(/no token/i);
+    expect(api.isAuthenticated).toBe(false);
+  });
+
+  it("surfaces the server's error text on a failed login", async () => {
+    const { impl } = stubFetch([{ status: 422, body: { error: "Invalid User or Password" } }]);
+    const api = new ApiClient("", impl);
+    await expect(api.login("a@b.c", "nope")).rejects.toThrow("Invalid User or Password");
+  });
+
+  it("sends the bearer token on dataTable calls", async () => {
+    const { api, calls } = await signedIn([{ status: 200, body: { ok: true } }]);
+    await api.dataTable({ action: "read" });
+    expect(calls[1]?.url).toBe("/dataTable");
+    expect(calls[1]?.headers["Authorization"]).toBe("Bearer token-1");
+  });
+
+  it("adopts the refreshed token from each response", async () => {
+    // The server mints a new token per request; a client that ignores it will
+    // eventually present a stale one, so this is the behaviour worth pinning.
+    const { api, calls } = await signedIn([
+      { status: 200, body: { token: "token-2" } },
+      { status: 200, body: { token: "token-3" } },
+    ]);
+    await api.dataTable({ action: "read" });
+    expect(calls[1]?.headers["Authorization"]).toBe("Bearer token-1");
+    await api.dataTable({ action: "read" });
+    expect(calls[2]?.headers["Authorization"]).toBe("Bearer token-2");
+  });
+
+  it("strips the token out of the body it returns", async () => {
+    const { api } = await signedIn([
+      { status: 200, body: { token: "token-2", file_content: "hello" } },
+    ]);
+    const body = await api.dataTable<Record<string, unknown>>({ action: "x" });
+    expect(body["file_content"]).toBe("hello");
+    expect(body["token"]).toBeUndefined();
+  });
+
+  it("treats 401 as the end of the session", async () => {
+    const { api } = await signedIn([{ status: 401, body: { error: "Unauthorized" } }]);
+    await expect(api.dataTable({ action: "read" })).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(api.isAuthenticated).toBe(false);
+    expect(api.currentUser).toBeNull();
+  });
+
+  it("refuses to call dataTable without a session", async () => {
+    const { impl } = stubFetch([]);
+    const api = new ApiClient("", impl);
+    await expect(api.dataTable({ action: "read" })).rejects.toBeInstanceOf(SessionExpiredError);
+  });
+
+  it("reports a non-401 failure with the server's message", async () => {
+    const { api } = await signedIn([{ status: 400, body: { error: "not a valid json file" } }]);
+    await expect(api.dataTable({ action: "save" })).rejects.toThrow("not a valid json file");
+    // A 400 is about the request, not the session; stay signed in.
+    expect(api.isAuthenticated).toBe(true);
+  });
+
+  it("survives a non-json error body", async () => {
+    const { api } = await signedIn([{ status: 502, body: "<html>bad gateway</html>" }]);
+    await expect(api.dataTable({ action: "read" })).rejects.toThrow(/bad gateway/);
+  });
+
+  it("resolves capabilities, with admin passing everything", async () => {
+    const { api } = await signedIn([]);
+    expect(api.can("workspace_ide")).toBe(true);
+    expect(api.can("run_pipelines")).toBe(false);
+
+    const { impl } = stubFetch([
+      { status: 200, body: { user_email: "root@x", is_admin: true, capabilities: [], token: "t" } },
+    ]);
+    const admin = new ApiClient("", impl);
+    await admin.login("root@x", "pw");
+    expect(admin.can("anything_at_all")).toBe(true);
+  });
+
+  it("notifies subscribers on sign-in and sign-out", async () => {
+    const seen: Array<string | null> = [];
+    const { impl } = stubFetch([LOGIN_OK]);
+    const api = new ApiClient("", impl);
+    api.subscribe((u) => seen.push(u?.email ?? null));
+    await api.login("ada@example.com", "pw");
+    api.logout();
+    expect(seen).toEqual(["ada@example.com", null]);
+  });
+});

--- a/jetsclient_ide/src/api/client.ts
+++ b/jetsclient_ide/src/api/client.ts
@@ -94,7 +94,11 @@ export class ApiClient {
     const res = await this.fetchImpl(`${this.baseUrl}/login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, password }),
+      // The field is `user_email`, not `email`: /login unmarshals straight into
+      // user.User, whose Email carries `json:"user_email"` (jets/user/user.go).
+      // Sending `email` unmarshals to an empty string and the server answers
+      // "required Email" while the form plainly had one in it.
+      body: JSON.stringify({ user_email: email, password }),
     });
     const body = (await this.readJson(res)) as LoginResponse;
     if (!res.ok) {

--- a/jetsclient_ide/src/api/client.ts
+++ b/jetsclient_ide/src/api/client.ts
@@ -1,0 +1,202 @@
+/**
+ * The single way this app talks to the Go apiserver.
+ *
+ * Three behaviours of that server drive the shape of this file, and all three are
+ * load-bearing rather than incidental:
+ *
+ *  - Auth is `Authorization: Bearer <token>`, parsed in jets/user/token.go.
+ *  - **Every authenticated response carries a refreshed token.** `authh` in
+ *    jets/apiserver/server.go mints one on each request, so a client that does not
+ *    read `token` out of each response body will eventually present a stale one.
+ *    Sessions therefore last as long as the user keeps working, and stop lasting
+ *    the moment they stop.
+ *  - A 401 means the session is over; there is no refresh endpoint to fall back to.
+ *
+ * The token is deliberately kept in memory only. Putting it in localStorage would
+ * outlive the tab and widen the blast radius of any script injection, and the
+ * refresh-per-response behaviour above means a reload costs one login rather than a
+ * lost day's work.
+ */
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+/** Thrown on 401 so callers can drop to the login screen without sniffing status codes. */
+export class SessionExpiredError extends ApiError {
+  constructor() {
+    super("Session expired, please sign in again.", 401);
+    this.name = "SessionExpiredError";
+  }
+}
+
+export interface User {
+  name: string;
+  email: string;
+  isAdmin: boolean;
+  capabilities: string[];
+  jetstoreVersion: string;
+  devMode: boolean;
+}
+
+/** Shape of the /login response (jets/apiserver/api_users.go). */
+interface LoginResponse {
+  name?: string;
+  user_email?: string;
+  is_admin?: boolean;
+  capabilities?: string[] | null;
+  token?: string;
+  dev_mode?: string;
+  jetstore_version?: string;
+}
+
+type Listener = (user: User | null) => void;
+
+export class ApiClient {
+  private token: string | null = null;
+  private user: User | null = null;
+  private listeners = new Set<Listener>();
+
+  /**
+   * `fetchImpl` is injectable so the tests can drive this class without a network
+   * or a DOM; production callers use the default.
+   */
+  constructor(
+    private readonly baseUrl = "",
+    private readonly fetchImpl: typeof fetch = globalThis.fetch.bind(globalThis),
+  ) {}
+
+  get currentUser(): User | null {
+    return this.user;
+  }
+
+  get isAuthenticated(): boolean {
+    return this.token !== null;
+  }
+
+  /** Notified on sign-in and sign-out so React can re-render the shell. */
+  subscribe(fn: Listener): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+
+  private emit(): void {
+    for (const fn of this.listeners) fn(this.user);
+  }
+
+  async login(email: string, password: string): Promise<User> {
+    const res = await this.fetchImpl(`${this.baseUrl}/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    const body = (await this.readJson(res)) as LoginResponse;
+    if (!res.ok) {
+      throw new ApiError(this.errorText(body, "Sign in failed."), res.status);
+    }
+    if (!body.token) {
+      throw new ApiError("Sign in succeeded but returned no token.", res.status);
+    }
+    this.token = body.token;
+    this.user = {
+      name: body.name ?? "",
+      email: body.user_email ?? email,
+      isAdmin: body.is_admin === true,
+      capabilities: body.capabilities ?? [],
+      jetstoreVersion: body.jetstore_version ?? "",
+      devMode: body.dev_mode === "true",
+    };
+    this.emit();
+    return this.user;
+  }
+
+  logout(): void {
+    this.token = null;
+    this.user = null;
+    this.emit();
+  }
+
+  /** True when the signed-in user holds a capability. Admin passes everything. */
+  can(capability: string): boolean {
+    if (!this.user) return false;
+    return this.user.isAdmin || this.user.capabilities.includes(capability);
+  }
+
+  /**
+   * POST to /dataTable, the action multiplexer (see the switch in
+   * jets/apiserver/api_tables.go). Returns the decoded body with the refreshed
+   * token already consumed and stripped.
+   */
+  async dataTable<T = Record<string, unknown>>(
+    payload: Record<string, unknown>,
+  ): Promise<T> {
+    return this.post<T>("/dataTable", payload);
+  }
+
+  private async post<T>(path: string, payload: Record<string, unknown>): Promise<T> {
+    if (!this.token) throw new SessionExpiredError();
+    const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.token}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (res.status === 401) {
+      this.logout();
+      throw new SessionExpiredError();
+    }
+
+    const body = await this.readJson(res);
+    // Consume the refreshed token before anything else looks at the body, and
+    // remove it: the rest of the app has no business holding a credential, and
+    // this body is rendered in places a user can read and copy.
+    const refreshed = this.takeToken(body);
+    if (refreshed) this.token = refreshed;
+
+    if (!res.ok) {
+      throw new ApiError(this.errorText(body, "The server rejected the request."), res.status);
+    }
+    return body as T;
+  }
+
+  private takeToken(body: unknown): string | null {
+    if (!body || typeof body !== "object") return null;
+    const record = body as Record<string, unknown>;
+    const token = record["token"];
+    if (typeof token !== "string" || token === "") return null;
+    delete record["token"];
+    return token;
+  }
+
+  private async readJson(res: Response): Promise<unknown> {
+    const text = await res.text();
+    if (text === "") return {};
+    try {
+      return JSON.parse(text);
+    } catch {
+      // The server answers errors as json, but a proxy or a panic can produce
+      // html or a bare string; surface it rather than a parse error.
+      return { error: text };
+    }
+  }
+
+  private errorText(body: unknown, fallback: string): string {
+    if (body && typeof body === "object") {
+      const record = body as Record<string, unknown>;
+      for (const key of ["error", "message"]) {
+        const v = record[key];
+        if (typeof v === "string" && v !== "") return v;
+      }
+    }
+    return fallback;
+  }
+}

--- a/jetsclient_ide/src/api/workspace.test.ts
+++ b/jetsclient_ide/src/api/workspace.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { ApiClient } from "./client";
+import { WorkspaceApi, decodeLabel, fileNameOf, walk, type WorkspaceNode } from "./workspace";
+
+function node(partial: Partial<WorkspaceNode>): WorkspaceNode {
+  return {
+    key: "k",
+    pageMatchKey: "",
+    type: "file",
+    size: 0,
+    label: "f.jr",
+    route_path: "",
+    route_params: null,
+    children: null,
+    ...partial,
+  };
+}
+
+function stub(queue: Array<{ status: number; body: unknown }>) {
+  const calls: Array<{ url: string; body: any }> = [];
+  const impl = (async (url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), body: init?.body ? JSON.parse(String(init.body)) : undefined });
+    const next = queue.shift() ?? { status: 200, body: {} };
+    return {
+      ok: next.status < 300,
+      status: next.status,
+      text: async () => JSON.stringify(next.body),
+    } as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+async function api(queue: Array<{ status: number; body: unknown }>) {
+  const { impl, calls } = stub([{ status: 200, body: { token: "t", user_email: "a@b.c" } }, ...queue]);
+  const client = new ApiClient("", impl);
+  await client.login("a@b.c", "pw");
+  return { ws: new WorkspaceApi(client), calls };
+}
+
+describe("fileNameOf", () => {
+  it("prefers route_params.file_name", () => {
+    const n = node({ route_params: { file_name: "jet_rules%2Fa.jr" }, pageMatchKey: "other" });
+    expect(fileNameOf(n)).toBe("jet_rules%2Fa.jr");
+  });
+
+  it("falls back to pageMatchKey", () => {
+    expect(fileNameOf(node({ pageMatchKey: "lookups%2Fb.jr" }))).toBe("lookups%2Fb.jr");
+  });
+
+  it("returns null for directories and sections", () => {
+    expect(fileNameOf(node({ type: "dir", pageMatchKey: "jet_rules" }))).toBeNull();
+    expect(fileNameOf(node({ type: "section", pageMatchKey: "s" }))).toBeNull();
+  });
+});
+
+describe("decodeLabel", () => {
+  it("decodes the escaped path the server issues", () => {
+    expect(decodeLabel("jet_rules%2Fmain%2Frules.jr")).toBe("jet_rules/main/rules.jr");
+  });
+
+  it("returns the input unchanged when it will not decode", () => {
+    expect(decodeLabel("100%")).toBe("100%");
+  });
+});
+
+describe("walk", () => {
+  it("visits every node depth-first", () => {
+    const tree = [
+      node({
+        type: "dir",
+        label: "jet_rules",
+        children: [node({ label: "a.jr" }), node({ label: "b.jr" })],
+      }),
+      node({ label: "c.jr" }),
+    ];
+    expect([...walk(tree)].map((n) => n.label)).toEqual(["jet_rules", "a.jr", "b.jr", "c.jr"]);
+  });
+});
+
+describe("WorkspaceApi", () => {
+  it("requests the file tree with the shape the Go handler expects", async () => {
+    const { ws, calls } = await api([
+      { status: 200, body: { result_type: "workspace_file_structure", result_data: [] } },
+    ]);
+    await ws.fileTree("cedargate_ws");
+    expect(calls[1]?.body).toMatchObject({
+      action: "workspace_query_structure",
+      fromClauses: [{ table: "workspace_file_structure" }],
+      workspaceName: "cedargate_ws",
+    });
+  });
+
+  it("returns an empty tree when the server answers with another result type", async () => {
+    const { ws } = await api([{ status: 200, body: { result_type: "something_else" } }]);
+    expect(await ws.fileTree("ws")).toEqual([]);
+  });
+
+  it("reads a file, passing file_name through without re-encoding", async () => {
+    const { ws, calls } = await api([{ status: 200, body: { file_content: "rule text" } }]);
+    const n = node({
+      label: "rules.jr",
+      route_params: { workspace_name: "ws", file_name: "jet_rules%2Frules.jr" },
+    });
+    const file = await ws.readFile("ws", n);
+
+    expect(file.content).toBe("rule text");
+    expect(file.fileName).toBe("jet_rules%2Frules.jr");
+    expect(file.label).toBe("jet_rules/rules.jr");
+    expect(calls[1]?.body.data[0].file_name).toBe("jet_rules%2Frules.jr");
+    expect(calls[1]?.body.action).toBe("get_workspace_file_content");
+  });
+
+  it("treats a missing file_content as an empty file rather than failing", async () => {
+    const { ws } = await api([{ status: 200, body: {} }]);
+    const file = await ws.readFile("ws", node({ pageMatchKey: "a.jr" }));
+    expect(file.content).toBe("");
+  });
+
+  it("refuses to read a directory", async () => {
+    const { ws } = await api([]);
+    await expect(ws.readFile("ws", node({ type: "dir", label: "d" }))).rejects.toThrow(/not a file/);
+  });
+
+  it("has no size limit — a multi-megabyte file loads like any other", async () => {
+    // The Flutter client refused anything at or above 250,000 bytes. The largest
+    // rule file in the corpus is ~1.18 MB, and must simply open.
+    const big = "x".repeat(1_200_000);
+    const { ws } = await api([{ status: 200, body: { file_content: big } }]);
+    const file = await ws.readFile("ws", node({ pageMatchKey: "big.jr", size: 1_200_000 }));
+    expect(file.content.length).toBe(1_200_000);
+  });
+
+  it("saves with the action and payload the server switches on", async () => {
+    const { ws, calls } = await api([{ status: 200, body: {} }]);
+    await ws.saveFile("ws", "jet_rules%2Fa.jr", "new text");
+    expect(calls[1]?.body).toMatchObject({
+      action: "save_workspace_file_content",
+      workspaceName: "ws",
+      data: [{ file_name: "jet_rules%2Fa.jr", file_content: "new text" }],
+    });
+  });
+
+  it("maps the workspace registry query onto summaries", async () => {
+    const { ws } = await api([
+      { status: 200, body: { rows: [["cedargate_ws", "git@x", "cgt_ai"], ["jets_ws", "git@y", "jets_ai"]] } },
+    ]);
+    const list = await ws.listWorkspaces();
+    expect(list).toEqual([
+      { name: "cedargate_ws", uri: "git@x", branch: "cgt_ai" },
+      { name: "jets_ws", uri: "git@y", branch: "jets_ai" },
+    ]);
+  });
+});

--- a/jetsclient_ide/src/api/workspace.ts
+++ b/jetsclient_ide/src/api/workspace.ts
@@ -1,0 +1,137 @@
+/**
+ * Typed wrappers over the workspace actions of /dataTable.
+ *
+ * The wire shapes here are not invented; they mirror the Go side:
+ *   - the tree node is `wsfile.WorkspaceNode` (jets/datatable/wsfile/visitor.go)
+ *   - the actions are the `workspace_*` arms of the switch in
+ *     jets/apiserver/api_tables.go
+ *   - `file_name` is **url-escaped by the server** when it builds the tree and
+ *     url-unescaped again when it reads the file, so it is passed back exactly as
+ *     received and never decoded on the way through.
+ *
+ * Note what is deliberately absent: a size limit. The Flutter client refused to
+ * open anything at or above 250,000 bytes because its editor laid the whole
+ * document out per frame. CodeMirror virtualises by viewport, so the limit has no
+ * reason to exist here and the largest rule file in the corpus (1.18 MB) is
+ * unremarkable.
+ */
+
+import type { ApiClient } from "./client";
+
+/** Mirrors wsfile.WorkspaceNode. */
+export interface WorkspaceNode {
+  key: string;
+  pageMatchKey: string;
+  /** "dir" | "file" | "section" */
+  type: string;
+  size: number;
+  label: string;
+  route_path: string;
+  route_params: Record<string, string> | null;
+  children: WorkspaceNode[] | null;
+}
+
+export interface WorkspaceSummary {
+  name: string;
+  uri: string;
+  branch: string;
+}
+
+/** A file opened for editing. */
+export interface WorkspaceFile {
+  /** Url-escaped relative path, exactly as the server issued it. */
+  fileName: string;
+  /** Human-readable path, for tab labels and titles. */
+  label: string;
+  content: string;
+}
+
+export class WorkspaceApi {
+  constructor(private readonly api: ApiClient) {}
+
+  /** The workspaces this user may open, from jetsapi.workspace_registry. */
+  async listWorkspaces(): Promise<WorkspaceSummary[]> {
+    const body = await this.api.dataTable<{ rows?: unknown[][]; columns?: unknown }>({
+      action: "raw_query",
+      query:
+        "SELECT workspace_name, workspace_uri, workspace_branch " +
+        "FROM jetsapi.workspace_registry ORDER BY workspace_name ASC LIMIT 200",
+    });
+    const rows = Array.isArray(body.rows) ? body.rows : [];
+    return rows.map((r) => ({
+      name: String(r?.[0] ?? ""),
+      uri: String(r?.[1] ?? ""),
+      branch: String(r?.[2] ?? ""),
+    }));
+  }
+
+  /** The file tree for a workspace. */
+  async fileTree(workspaceName: string): Promise<WorkspaceNode[]> {
+    const body = await this.api.dataTable<{
+      result_type?: string;
+      result_data?: WorkspaceNode[];
+    }>({
+      action: "workspace_query_structure",
+      fromClauses: [{ table: "workspace_file_structure" }],
+      workspaceName,
+      data: [{ workspace_name: workspaceName }],
+    });
+    if (body.result_type !== "workspace_file_structure" || !Array.isArray(body.result_data)) {
+      return [];
+    }
+    return body.result_data;
+  }
+
+  async readFile(workspaceName: string, node: WorkspaceNode): Promise<WorkspaceFile> {
+    const fileName = fileNameOf(node);
+    if (!fileName) throw new Error(`${node.label} is not a file`);
+    const body = await this.api.dataTable<{ file_content?: string }>({
+      action: "get_workspace_file_content",
+      workspaceName,
+      data: [{ ...(node.route_params ?? {}), file_name: fileName }],
+    });
+    return {
+      fileName,
+      label: decodeLabel(fileName),
+      content: body.file_content ?? "",
+    };
+  }
+
+  /**
+   * Save. The server validates any `.json` file before writing (it refuses to
+   * persist one that will not parse), so a 400 here is frequently a real syntax
+   * error in the buffer rather than a transport problem — worth surfacing verbatim.
+   */
+  async saveFile(workspaceName: string, fileName: string, content: string): Promise<void> {
+    await this.api.dataTable({
+      action: "save_workspace_file_content",
+      workspaceName,
+      data: [{ file_name: fileName, file_content: content }],
+    });
+  }
+}
+
+/** The escaped relative path for a file node, or null for anything else. */
+export function fileNameOf(node: WorkspaceNode): string | null {
+  if (node.type !== "file") return null;
+  const fromParams = node.route_params?.["file_name"];
+  if (typeof fromParams === "string" && fromParams !== "") return fromParams;
+  return node.pageMatchKey !== "" ? node.pageMatchKey : null;
+}
+
+/** Turn the escaped wire path back into something readable for a tab label. */
+export function decodeLabel(escaped: string): string {
+  try {
+    return decodeURIComponent(escaped.replace(/\+/g, " "));
+  } catch {
+    return escaped;
+  }
+}
+
+/** Depth-first walk, used by the tree filter and by the tests. */
+export function* walk(nodes: WorkspaceNode[]): Generator<WorkspaceNode> {
+  for (const n of nodes) {
+    yield n;
+    if (n.children) yield* walk(n.children);
+  }
+}

--- a/jetsclient_ide/src/components/FileTree.tsx
+++ b/jetsclient_ide/src/components/FileTree.tsx
@@ -1,0 +1,132 @@
+import { useMemo, useState } from "react";
+import { fileNameOf, type WorkspaceNode } from "../api/workspace";
+
+interface Props {
+  nodes: WorkspaceNode[];
+  activeFile: string | null;
+  onOpen: (node: WorkspaceNode) => void;
+}
+
+/** Human-readable size. Files here run from a few bytes to a few megabytes. */
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Keeps a node whose own label matches, or which has a surviving descendant. */
+function filterTree(nodes: WorkspaceNode[], needle: string): WorkspaceNode[] {
+  if (needle === "") return nodes;
+  const lower = needle.toLowerCase();
+  const keep = (n: WorkspaceNode): WorkspaceNode | null => {
+    const children = n.children ? n.children.map(keep).filter((c): c is WorkspaceNode => c !== null) : [];
+    if (n.label.toLowerCase().includes(lower) || children.length > 0) {
+      return { ...n, children: children.length > 0 ? children : n.children };
+    }
+    return null;
+  };
+  return nodes.map(keep).filter((n): n is WorkspaceNode => n !== null);
+}
+
+function TreeNode({
+  node,
+  depth,
+  activeFile,
+  onOpen,
+  forceOpen,
+}: {
+  node: WorkspaceNode;
+  depth: number;
+  activeFile: string | null;
+  onOpen: (n: WorkspaceNode) => void;
+  forceOpen: boolean;
+}) {
+  const [open, setOpen] = useState(depth < 1);
+  const expanded = forceOpen || open;
+  const isFile = node.type === "file";
+  const fileName = fileNameOf(node);
+  const isActive = isFile && fileName !== null && fileName === activeFile;
+
+  if (isFile) {
+    return (
+      <button
+        type="button"
+        className={`tree-row tree-file${isActive ? " is-active" : ""}`}
+        style={{ paddingLeft: `${8 + depth * 13}px` }}
+        onClick={() => onOpen(node)}
+        title={node.label}
+      >
+        <span className="tree-label">{node.label}</span>
+        <span className="tree-size">{formatSize(node.size)}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="tree-row tree-dir"
+        style={{ paddingLeft: `${8 + depth * 13}px` }}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <span className={`tree-caret${expanded ? " is-open" : ""}`} aria-hidden="true">
+          ▸
+        </span>
+        <span className="tree-label">{node.label}</span>
+      </button>
+      {expanded && node.children && (
+        <div>
+          {node.children.map((child, i) => (
+            <TreeNode
+              key={`${child.key}:${child.label}:${i}`}
+              node={child}
+              depth={depth + 1}
+              activeFile={activeFile}
+              onOpen={onOpen}
+              forceOpen={forceOpen}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function FileTree({ nodes, activeFile, onOpen }: Props) {
+  const [filter, setFilter] = useState("");
+  const filtered = useMemo(() => filterTree(nodes, filter.trim()), [nodes, filter]);
+
+  return (
+    <div className="tree">
+      <div className="tree-filter">
+        <input
+          type="search"
+          value={filter}
+          placeholder="Filter files"
+          onChange={(e) => setFilter(e.target.value)}
+          aria-label="Filter files"
+        />
+      </div>
+      <div className="tree-scroll">
+        {filtered.length === 0 ? (
+          <p className="tree-empty">No files match “{filter}”.</p>
+        ) : (
+          filtered.map((n, i) => (
+            <TreeNode
+              key={`${n.key}:${n.label}:${i}`}
+              node={n}
+              depth={0}
+              activeFile={activeFile}
+              onOpen={onOpen}
+              // While filtering, show the matches rather than making the user
+              // expand to find them.
+              forceOpen={filter.trim() !== ""}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/jetsclient_ide/src/components/Login.tsx
+++ b/jetsclient_ide/src/components/Login.tsx
@@ -1,0 +1,67 @@
+import { useState, type FormEvent } from "react";
+
+interface Props {
+  onSubmit: (email: string, password: string) => Promise<void>;
+  version: string;
+}
+
+export function Login({ onSubmit, version }: Props) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      await onSubmit(email, password);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sign in failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="login-page">
+      <form className="login-card" onSubmit={submit}>
+        <h1>Workspace IDE</h1>
+        <p className="login-sub">Sign in with your JetStore account.</p>
+
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          autoComplete="username"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoFocus
+        />
+
+        <label htmlFor="password">Password</label>
+        <input
+          id="password"
+          type="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+
+        {error && (
+          <p className="login-error" role="alert">
+            {error}
+          </p>
+        )}
+
+        <button type="submit" className="btn btn-primary" disabled={busy}>
+          {busy ? "Signing in…" : "Sign in"}
+        </button>
+        {version && <p className="login-version">JetStore {version}</p>}
+      </form>
+    </div>
+  );
+}

--- a/jetsclient_ide/src/editor/Editor.tsx
+++ b/jetsclient_ide/src/editor/Editor.tsx
@@ -1,0 +1,138 @@
+/**
+ * The CodeMirror 6 editor, wrapped for React.
+ *
+ * The wrapper exists because CodeMirror owns its own DOM and its own state, and
+ * React must not fight it for either. So the view is created once for the lifetime
+ * of the mount, and afterwards React communicates only through transactions:
+ *
+ *  - a new `docKey` (a different file) resets the document wholesale
+ *  - a language change is applied through a compartment rather than by rebuilding
+ *  - the *content* prop is deliberately not synced back into the view, because the
+ *    user is the source of truth for it while the file is open
+ *
+ * That last point is the mirror image of the bug in the Flutter client, where
+ * every rebuild constructed a fresh field and the buffer had to be re-seeded from
+ * form state each time.
+ */
+
+import { useEffect, useRef } from "react";
+import { EditorState, Compartment, type Extension } from "@codemirror/state";
+import { EditorView, keymap, lineNumbers, highlightActiveLine,
+  highlightActiveLineGutter, drawSelection, rectangularSelection,
+  highlightSpecialChars, crosshairCursor } from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { searchKeymap, highlightSelectionMatches, search } from "@codemirror/search";
+import { bracketMatching, foldGutter, foldKeymap, indentOnInput,
+  indentUnit } from "@codemirror/language";
+import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+import { languageExtension } from "./language";
+import { jetStoreEditorTheme } from "./theme";
+
+export interface EditorProps {
+  /** Changes when a different file is shown; drives a full document reset. */
+  docKey: string;
+  /** File name, used to pick the language. */
+  fileName: string;
+  /** Initial text for `docKey`. Later changes to it are ignored by design. */
+  content: string;
+  readOnly?: boolean;
+  onChange?: (value: string) => void;
+  onSave?: () => void;
+}
+
+export function Editor({ docKey, fileName, content, readOnly, onChange, onSave }: EditorProps) {
+  const host = useRef<HTMLDivElement | null>(null);
+  const view = useRef<EditorView | null>(null);
+  const language = useRef(new Compartment());
+  const editable = useRef(new Compartment());
+
+  // Kept in refs so changing a handler never tears down the view.
+  const changeHandler = useRef(onChange);
+  const saveHandler = useRef(onSave);
+  changeHandler.current = onChange;
+  saveHandler.current = onSave;
+
+  useEffect(() => {
+    if (!host.current) return;
+
+    const saveKeymap = keymap.of([
+      {
+        key: "Mod-s",
+        preventDefault: true,
+        run: () => {
+          saveHandler.current?.();
+          return true;
+        },
+      },
+    ]);
+
+    const extensions: Extension[] = [
+      lineNumbers(),
+      foldGutter(),
+      highlightSpecialChars(),
+      history(),
+      drawSelection(),
+      EditorState.allowMultipleSelections.of(true),
+      indentOnInput(),
+      indentUnit.of("  "),
+      bracketMatching(),
+      closeBrackets(),
+      rectangularSelection(),
+      crosshairCursor(),
+      highlightActiveLine(),
+      highlightActiveLineGutter(),
+      highlightSelectionMatches(),
+      search({ top: true }),
+      // Save must come before the default keymap so Mod-s is not swallowed.
+      saveKeymap,
+      keymap.of([...closeBracketsKeymap, ...defaultKeymap, ...searchKeymap,
+        ...historyKeymap, ...foldKeymap, indentWithTab]),
+      EditorView.lineWrapping,
+      jetStoreEditorTheme,
+      language.current.of(languageExtension(fileName)),
+      editable.current.of(EditorView.editable.of(!readOnly)),
+      EditorView.updateListener.of((u) => {
+        if (u.docChanged) changeHandler.current?.(u.state.doc.toString());
+      }),
+    ];
+
+    const v = new EditorView({
+      state: EditorState.create({ doc: content, extensions }),
+      parent: host.current,
+    });
+    view.current = v;
+    return () => {
+      v.destroy();
+      view.current = null;
+    };
+    // Created once per mount. Document and language updates are handled by the
+    // effects below, as transactions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // A different file: replace the document and reset history so undo cannot walk
+  // backwards into the previous file's text.
+  useEffect(() => {
+    const v = view.current;
+    if (!v) return;
+    v.dispatch({
+      changes: { from: 0, to: v.state.doc.length, insert: content },
+      selection: { anchor: 0 },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [docKey]);
+
+  useEffect(() => {
+    view.current?.dispatch({
+      effects: language.current.reconfigure(languageExtension(fileName)),
+    });
+  }, [fileName]);
+
+  useEffect(() => {
+    view.current?.dispatch({
+      effects: editable.current.reconfigure(EditorView.editable.of(!readOnly)),
+    });
+  }, [readOnly]);
+
+  return <div className="editor-host" ref={host} />;
+}

--- a/jetsclient_ide/src/editor/jetrules.test.ts
+++ b/jetsclient_ide/src/editor/jetrules.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { StringStream } from "@codemirror/language";
+import { jetRulesParser, type JetRulesState } from "./jetrules";
+
+/**
+ * Drives the stream parser the way CodeMirror does — a line at a time, carrying
+ * state across — and returns [text, token] pairs with whitespace dropped.
+ */
+function tokenize(code: string): Array<[string, string | null]> {
+  const state: JetRulesState = jetRulesParser.startState!(2);
+  const out: Array<[string, string | null]> = [];
+  for (const line of code.split("\n")) {
+    const stream = new StringStream(line, 2, 2);
+    while (!stream.eol()) {
+      const start = stream.pos;
+      const token = jetRulesParser.token(stream, state) ?? null;
+      const text = line.slice(start, stream.pos);
+      if (stream.pos === start) throw new Error(`tokeniser stalled at ${start}: ${line}`);
+      if (text.trim() !== "") out.push([text, token]);
+    }
+  }
+  return out;
+}
+
+/** The token assigned to the first occurrence of `text`. */
+function tokenFor(code: string, text: string): string | null | undefined {
+  return tokenize(code).find(([t]) => t === text)?.[1];
+}
+
+describe("jetrules stream parser", () => {
+  it("advances on every input it is given", () => {
+    // The guard in tokenize() throws if the parser ever fails to consume; this is
+    // the case that matters because a stalled tokeniser hangs the editor.
+    const odd = '~ ` | & % ^ \\ é \t []{}();:.,\n@Unknown $notAProperty ?';
+    expect(() => tokenize(odd)).not.toThrow();
+  });
+
+  it("highlights comments to end of line", () => {
+    const toks = tokenize("# a comment with \"quotes\" and ?vars\nclass Foo");
+    expect(toks[0]?.[1]).toBe("comment");
+    // The comment must not leak into the next line.
+    expect(tokenFor("# c\nclass Foo", "class")).toBe("keyword");
+  });
+
+  it("recognises declarators, keywords and types", () => {
+    expect(tokenFor('volatile_resource tag = "tag";', "volatile_resource")).toBe("storage");
+    expect(tokenFor("resource x", "resource")).toBe("storage");
+    expect(tokenFor("lookup_table PlaceOfServiceLookup {", "lookup_table")).toBe("keyword");
+    expect(tokenFor('"NAME" as text', "text")).toBe("type");
+  });
+
+  it("recognises rule variables and rule headers", () => {
+    expect(tokenFor("(?state rdf:type jets:State)", "?state")).toBe("ruleVariable");
+    expect(tokenFor("[AM_State01]:", "AM_State01")).toBe("ruleName");
+    // `[` used as a list opener must not make the next identifier a rule name.
+    expect(tokenFor('$key = ["CODE"]', '"CODE"')).toBe("string");
+  });
+
+  it("splits namespaced identifiers into prefix and qualified name", () => {
+    const toks = tokenize("(?s rdf:type jets:State)");
+    expect(toks.find(([t]) => t === "rdf")?.[1]).toBe("namespace");
+    expect(toks.find(([t]) => t === "type")?.[1]).toBe("qualifiedName");
+    expect(toks.find(([t]) => t === "jets")?.[1]).toBe("namespace");
+    expect(toks.find(([t]) => t === "State")?.[1]).toBe("qualifiedName");
+  });
+
+  it("does not treat the colon after a rule header as a namespace", () => {
+    const toks = tokenize("[R1]:\n  (?a b:c)");
+    expect(toks.find(([t]) => t === "R1")?.[1]).toBe("ruleName");
+    expect(toks.find(([t]) => t === "b")?.[1]).toBe("namespace");
+  });
+
+  it("handles strings, escapes and config properties", () => {
+    expect(tokenFor('$csv_file = "lookups/a.csv",', "$csv_file")).toBe("configProperty");
+    // Enumerated in the grammar, so an unknown $name stays unhighlighted.
+    expect(tokenFor("$not_a_property = 1", "$not_a_property")).toBe(null);
+    const escaped = tokenize('"a \\" still string" class');
+    expect(escaped[0]?.[1]).toBe("string");
+    expect(escaped.find(([t]) => t === "class")?.[1]).toBe("keyword");
+  });
+
+  it("does not let an unterminated string swallow the next line", () => {
+    expect(tokenFor('"unterminated\nclass Foo', "class")).toBe("keyword");
+  });
+
+  it("recognises operators, functions and constants", () => {
+    expect(tokenFor("a -> b", "->")).toBe("operator");
+    expect(tokenFor("a and not b", "and")).toBe("operator");
+    expect(tokenFor("x >= 3", ">=")).toBe("operator");
+    expect(tokenFor("(?root p create_entity 0)", "create_entity")).toBe("function");
+    expect(tokenFor("x = true", "true")).toBe("constant");
+    expect(tokenFor("x = 42.5", "42.5")).toBe("number");
+  });
+
+  it("treats `array of` as one keyword", () => {
+    expect(tokenFor("array of text", "array of")).toBe("keyword");
+  });
+
+  it("tokenises a realistic rule without stalling or misreading structure", () => {
+    const src = [
+      "# Analysis rules",
+      'volatile_resource hasAnalysisRoot = "hasAnalysisRoot";',
+      "",
+      "[AM_State02]:",
+      "  (?state rdf:type jets:State).",
+      "  (?state hasAnalysisRoot ?root)",
+      "  ->",
+      "  (?root am:hasPatientProfile create_entity 0)",
+      ";",
+    ].join("\n");
+    const toks = tokenize(src);
+    expect(toks.find(([t]) => t === "AM_State02")?.[1]).toBe("ruleName");
+    expect(toks.find(([t]) => t === "->")?.[1]).toBe("operator");
+    expect(toks.filter(([, k]) => k === "ruleVariable").length).toBe(4);
+  });
+});

--- a/jetsclient_ide/src/editor/jetrules.ts
+++ b/jetsclient_ide/src/editor/jetrules.ts
@@ -1,0 +1,267 @@
+/**
+ * A CodeMirror 6 mode for the JetRules DSL.
+ *
+ * Ported from `tools/vscode-jetrule/syntaxes/jetrule.tmLanguage.json`, which stays
+ * the reference for what the language looks like. That grammar is small — fourteen
+ * top-level patterns — which is why porting was cheaper than dragging in the
+ * TextMate runtime (vscode-textmate plus an Oniguruma wasm build) purely to reuse
+ * it. Keep the two in step: a construct highlighted in the VS Code extension and
+ * not here is a bug in this file.
+ *
+ * A `StreamLanguage` rather than a Lezer grammar, deliberately. Highlighting is all
+ * this needs today, and a stream tokeniser is a few hundred lines against a real
+ * parser's several thousand. If the IDE later wants folding by rule, structural
+ * selection, or go-to-definition, that is the point to invest in Lezer — those want
+ * a tree, and this cannot give them one.
+ */
+
+import { StreamLanguage, type StreamParser, type StringStream } from "@codemirror/language";
+import { LanguageSupport } from "@codemirror/language";
+import { tags as t } from "@lezer/highlight";
+
+/** `keyword.control.jetrule` */
+const STATEMENT_KEYWORDS = new Set([
+  "class",
+  "lookup_table",
+  "triple",
+  "rule_sequence",
+  "main",
+  "jetstore_config",
+]);
+
+/** `storage.modifier.jetrule` */
+const STORAGE_DECLARATORS = new Set(["resource", "volatile_resource"]);
+
+/** `storage.type.jetrule` */
+const TYPES = new Set([
+  "int",
+  "uint",
+  "long",
+  "ulong",
+  "double",
+  "text",
+  "date",
+  "datetime",
+  "bool",
+]);
+
+/** `constant.language.jetrule` */
+const CONSTANTS = new Set(["true", "false", "null"]);
+
+/** `support.function.jetrule` */
+const FUNCTIONS = new Set(["create_uuid_resource", "create_entity", "toText"]);
+
+/** `keyword.operator.logical.jetrule` */
+const LOGICAL_OPERATORS = new Set(["and", "or", "not"]);
+
+/**
+ * `support.type.property-name.jetrule` — the `$`-prefixed configuration keys. The
+ * grammar enumerates them rather than matching `$\w+`, so an unknown `$foo` stays
+ * unhighlighted and reads as the typo it probably is. That is worth preserving.
+ */
+const CONFIG_PROPERTIES = new Set([
+  "base_classes",
+  "data_properties",
+  "object_properties",
+  "grouping_properties",
+  "as_table",
+  "max_looping",
+  "max_rule_exec",
+  "input_types",
+  "main_rule_sets",
+  "table_name",
+  "csv_file",
+  "key",
+  "columns",
+]);
+
+const IDENT = /^[A-Za-z_][A-Za-z0-9_]*/;
+
+export interface JetRulesState {
+  /** Inside a double-quoted string that has not closed yet. */
+  inString: boolean;
+  /** Saw `[`; the next identifier names a rule. */
+  expectRuleName: boolean;
+  /** Previous token was a namespace prefix, so the name after `:` is a type. */
+  afterNamespace: boolean;
+}
+
+export const jetRulesParser: StreamParser<JetRulesState> = {
+  name: "jetrule",
+
+  startState(): JetRulesState {
+    return { inString: false, expectRuleName: false, afterNamespace: false };
+  },
+
+  token(stream: StringStream, state: JetRulesState): string | null {
+    if (state.inString) return consumeString(stream, state);
+
+    if (stream.eatSpace()) return null;
+
+    // Comments run to end of line.
+    if (stream.eat("#")) {
+      stream.skipToEnd();
+      return "comment";
+    }
+
+    if (stream.eat('"')) {
+      state.inString = true;
+      state.afterNamespace = false;
+      return consumeString(stream, state);
+    }
+
+    if (stream.match("@JetCompilerDirective")) {
+      state.afterNamespace = false;
+      return "directive";
+    }
+
+    // Rule variables: ?claim, ?state
+    if (stream.eat("?")) {
+      stream.match(IDENT);
+      state.afterNamespace = false;
+      return "ruleVariable";
+    }
+
+    // Configuration properties: $csv_file, $key
+    if (stream.eat("$")) {
+      const name = stream.match(IDENT);
+      state.afterNamespace = false;
+      return Array.isArray(name) && CONFIG_PROPERTIES.has(name[0]) ? "configProperty" : null;
+    }
+
+    // A rule header opens with `[`; the identifier after it names the rule.
+    if (stream.eat("[")) {
+      state.expectRuleName = true;
+      state.afterNamespace = false;
+      return "bracket";
+    }
+    if (stream.eat("]")) {
+      state.expectRuleName = false;
+      state.afterNamespace = false;
+      return "bracket";
+    }
+
+    // Multi-character operators first, so `->` does not tokenise as `-` then `>`.
+    if (stream.match("->") || stream.match("==") || stream.match("!=") ||
+        stream.match("<=") || stream.match(">=") || stream.match("r?")) {
+      state.afterNamespace = false;
+      return "operator";
+    }
+
+    const ch = stream.peek();
+    if (ch != null && "<>+-*/=".includes(ch)) {
+      stream.next();
+      state.afterNamespace = false;
+      return "operator";
+    }
+
+    if (ch === ":") {
+      stream.next();
+      // Leave `afterNamespace` alone: it was set by the identifier before this
+      // colon and is consumed by the identifier after it.
+      return "punctuation";
+    }
+
+    if (ch != null && "(){},;.".includes(ch)) {
+      stream.next();
+      state.afterNamespace = false;
+      return "punctuation";
+    }
+
+    if (stream.match(/^[0-9]+(\.[0-9]+)?/)) {
+      state.afterNamespace = false;
+      return "number";
+    }
+
+    const word = stream.match(IDENT);
+    if (Array.isArray(word)) return classifyWord(word[0], stream, state);
+
+    // Nothing matched; consume a character so the tokeniser always advances.
+    stream.next();
+    state.afterNamespace = false;
+    return null;
+  },
+
+  languageData: {
+    commentTokens: { line: "#" },
+    closeBrackets: { brackets: ["(", "[", "{", '"'] },
+    indentOnInput: /^\s*[}\])]$/,
+  },
+
+  tokenTable: {
+    directive: t.meta,
+    ruleName: t.labelName,
+    ruleVariable: t.variableName,
+    configProperty: t.propertyName,
+    storage: t.modifier,
+    keyword: t.keyword,
+    type: t.typeName,
+    constant: t.atom,
+    function: t.function(t.variableName),
+    namespace: t.namespace,
+    qualifiedName: t.typeName,
+    operator: t.operator,
+    punctuation: t.punctuation,
+    bracket: t.bracket,
+    comment: t.lineComment,
+    string: t.string,
+    number: t.number,
+  },
+};
+
+function consumeString(stream: StringStream, state: JetRulesState): string {
+  while (!stream.eol()) {
+    const c = stream.next();
+    if (c === "\\") {
+      // The grammar escapes only `\"` and `\\`, but consuming whatever follows a
+      // backslash is the safe reading and keeps an escaped quote from closing.
+      stream.next();
+      continue;
+    }
+    if (c === '"') {
+      state.inString = false;
+      return "string";
+    }
+  }
+  // Unterminated at end of line. JetRules strings do not span lines, so drop out
+  // rather than swallowing the rest of the file into one string token.
+  state.inString = false;
+  return "string";
+}
+
+function classifyWord(word: string, stream: StringStream, state: JetRulesState): string | null {
+  const wasAfterNamespace = state.afterNamespace;
+  state.afterNamespace = false;
+
+  if (state.expectRuleName) {
+    state.expectRuleName = false;
+    return "ruleName";
+  }
+
+  // `array of` is a single construct in the grammar.
+  if (word === "array" && stream.match(/^\s+of\b/)) return "keyword";
+
+  if (STORAGE_DECLARATORS.has(word)) return "storage";
+  if (STATEMENT_KEYWORDS.has(word)) return "keyword";
+  if (LOGICAL_OPERATORS.has(word)) return "operator";
+  if (CONSTANTS.has(word)) return "constant";
+  if (FUNCTIONS.has(word)) return "function";
+  if (TYPES.has(word)) return "type";
+
+  // `rdf:type`, `jets:State` — the prefix is a namespace, the name after the
+  // colon is the type it qualifies. The flag has to be set here and survive the
+  // colon token in between, which is why `token` leaves it alone for ":".
+  if (stream.match(/^\s*:\s*[A-Za-z_]/, false)) {
+    state.afterNamespace = true;
+    return "namespace";
+  }
+  if (wasAfterNamespace) return "qualifiedName";
+
+  return null;
+}
+
+export const jetRulesLanguage = StreamLanguage.define(jetRulesParser);
+
+export function jetRules(): LanguageSupport {
+  return new LanguageSupport(jetRulesLanguage);
+}

--- a/jetsclient_ide/src/editor/language.test.ts
+++ b/jetsclient_ide/src/editor/language.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isServerValidatedJson, languageNameFor } from "./language";
+
+describe("languageNameFor", () => {
+  it("recognises the extensions the workspace tree serves", () => {
+    expect(languageNameFor("jet_rules/main/rules.jr")).toBe("jetrules");
+    expect(languageNameFor("pipes_config/qc_medicalclaim.pc.json")).toBe("json");
+    expect(languageNameFor("data/lookups/uszips.sql")).toBe("sql");
+    expect(languageNameFor("lookups/drug_info.csv")).toBe("plain");
+  });
+
+  it("reads .jr.sql as sql, not as JetRules", () => {
+    // The Go visitor serves .jr and .jr.sql from the same directory, and the
+    // suffix test has to run in this order or every .jr.sql lands in the .jr arm.
+    expect(languageNameFor("jet_rules/a.jr.sql")).toBe("sql");
+  });
+
+  it("ignores case", () => {
+    expect(languageNameFor("A.JR")).toBe("jetrules");
+    expect(languageNameFor("B.JSON")).toBe("json");
+  });
+
+  it("falls back to plain for anything unknown", () => {
+    expect(languageNameFor("README")).toBe("plain");
+    expect(languageNameFor("")).toBe("plain");
+  });
+});
+
+describe("isServerValidatedJson", () => {
+  it("matches what SaveWorkspaceFileContent parses before writing", () => {
+    expect(isServerValidatedJson("a.json")).toBe(true);
+    expect(isServerValidatedJson("pipes_config/x.pc.json")).toBe(true);
+    expect(isServerValidatedJson("A.JSON")).toBe(true);
+    expect(isServerValidatedJson("a.jr")).toBe(false);
+  });
+});

--- a/jetsclient_ide/src/editor/language.ts
+++ b/jetsclient_ide/src/editor/language.ts
@@ -1,0 +1,48 @@
+/**
+ * Picks a CodeMirror language from a file name.
+ *
+ * The extensions here are the ones the workspace tree actually serves — the Go
+ * visitor filters to `.jr`, `.jr.sql`, `.csv`, plus the pipeline configs — so this
+ * is a closed set rather than a general-purpose registry. `.jr.sql` has to be
+ * tested before `.sql`, and both before the bare-extension fallback.
+ */
+
+import type { Extension } from "@codemirror/state";
+import { json } from "@codemirror/lang-json";
+import { sql } from "@codemirror/lang-sql";
+import { jetRules } from "./jetrules";
+
+export type LanguageName = "jetrules" | "json" | "sql" | "plain";
+
+export function languageNameFor(fileName: string): LanguageName {
+  const name = fileName.toLowerCase();
+  // `.jr.sql` is a JetRules-flavoured sql file; sql highlighting is the better fit
+  // for its body, and it must not fall through to the `.jr` branch.
+  if (name.endsWith(".jr.sql")) return "sql";
+  if (name.endsWith(".jr")) return "jetrules";
+  if (name.endsWith(".json")) return "json";
+  if (name.endsWith(".sql")) return "sql";
+  return "plain";
+}
+
+export function languageExtension(fileName: string): Extension[] {
+  switch (languageNameFor(fileName)) {
+    case "jetrules":
+      return [jetRules()];
+    case "json":
+      return [json()];
+    case "sql":
+      return [sql()];
+    case "plain":
+      return [];
+  }
+}
+
+/**
+ * Whether the server will parse this file before agreeing to save it.
+ * `SaveWorkspaceFileContent` rejects a `.json` file that does not parse, so the
+ * editor can warn about that locally instead of relying on a 400.
+ */
+export function isServerValidatedJson(fileName: string): boolean {
+  return fileName.toLowerCase().endsWith(".json");
+}

--- a/jetsclient_ide/src/editor/theme.ts
+++ b/jetsclient_ide/src/editor/theme.ts
@@ -1,0 +1,104 @@
+/**
+ * Editor theming.
+ *
+ * The tokens come from the same CSS custom properties the rest of the shell uses
+ * (see styles.css), so the editor follows the app's light/dark state without a
+ * second source of truth and without a JS theme switch — CodeMirror reads the
+ * cascade like anything else.
+ */
+
+import { EditorView } from "@codemirror/view";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags as t } from "@lezer/highlight";
+import type { Extension } from "@codemirror/state";
+
+const editorTheme = EditorView.theme({
+  "&": {
+    color: "var(--ink)",
+    backgroundColor: "var(--editor-bg)",
+    height: "100%",
+    fontSize: "13px",
+  },
+  ".cm-content": {
+    fontFamily: "var(--mono)",
+    padding: "10px 0",
+    caretColor: "var(--accent)",
+  },
+  ".cm-scroller": { fontFamily: "var(--mono)", lineHeight: "1.6" },
+  "&.cm-focused": { outline: "none" },
+  ".cm-gutters": {
+    backgroundColor: "var(--editor-gutter)",
+    color: "var(--ink-3)",
+    border: "none",
+    borderRight: "1px solid var(--rule)",
+  },
+  ".cm-activeLine": { backgroundColor: "var(--editor-active)" },
+  ".cm-activeLineGutter": {
+    backgroundColor: "var(--editor-active)",
+    color: "var(--ink-2)",
+  },
+  ".cm-selectionBackground, &.cm-focused .cm-selectionBackground, ::selection": {
+    backgroundColor: "var(--editor-selection)",
+  },
+  ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--accent)" },
+  ".cm-searchMatch": {
+    backgroundColor: "var(--editor-match)",
+    outline: "1px solid var(--accent)",
+  },
+  ".cm-searchMatch.cm-searchMatch-selected": { backgroundColor: "var(--editor-match-active)" },
+  ".cm-panels": {
+    backgroundColor: "var(--surface-2)",
+    color: "var(--ink)",
+    border: "none",
+    borderTop: "1px solid var(--rule)",
+  },
+  ".cm-panels input, .cm-panels button": {
+    fontFamily: "var(--sans)",
+    fontSize: "12px",
+    background: "var(--surface)",
+    color: "var(--ink)",
+    border: "1px solid var(--rule-2)",
+    borderRadius: "4px",
+    padding: "3px 6px",
+  },
+  ".cm-foldPlaceholder": {
+    backgroundColor: "var(--surface-2)",
+    border: "1px solid var(--rule-2)",
+    color: "var(--ink-3)",
+  },
+  ".cm-tooltip": {
+    background: "var(--surface)",
+    border: "1px solid var(--rule-2)",
+    borderRadius: "6px",
+    color: "var(--ink)",
+  },
+});
+
+/**
+ * One highlight style for both themes: every colour is a variable, so the palette
+ * swaps with the page rather than being duplicated per mode.
+ */
+const highlight = HighlightStyle.define([
+  { tag: t.lineComment, color: "var(--syn-comment)", fontStyle: "italic" },
+  { tag: t.blockComment, color: "var(--syn-comment)", fontStyle: "italic" },
+  { tag: t.string, color: "var(--syn-string)" },
+  { tag: t.number, color: "var(--syn-number)" },
+  { tag: t.keyword, color: "var(--syn-keyword)", fontWeight: "600" },
+  { tag: t.modifier, color: "var(--syn-keyword)", fontWeight: "600" },
+  { tag: t.atom, color: "var(--syn-constant)" },
+  { tag: t.bool, color: "var(--syn-constant)" },
+  { tag: t.null, color: "var(--syn-constant)" },
+  { tag: t.typeName, color: "var(--syn-type)" },
+  { tag: t.namespace, color: "var(--syn-namespace)" },
+  { tag: t.labelName, color: "var(--syn-rule)", fontWeight: "700" },
+  { tag: t.variableName, color: "var(--syn-variable)" },
+  { tag: t.propertyName, color: "var(--syn-property)" },
+  { tag: t.function(t.variableName), color: "var(--syn-function)" },
+  { tag: t.operator, color: "var(--syn-operator)" },
+  { tag: t.punctuation, color: "var(--ink-3)" },
+  { tag: t.bracket, color: "var(--ink-2)" },
+  { tag: t.meta, color: "var(--syn-meta)" },
+  { tag: t.invalid, color: "var(--crit)" },
+]);
+
+export const jetStoreEditorTheme: Extension = [editorTheme, syntaxHighlighting(highlight)];

--- a/jetsclient_ide/src/main.tsx
+++ b/jetsclient_ide/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+const host = document.getElementById("root");
+if (!host) throw new Error("missing #root");
+
+createRoot(host).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/jetsclient_ide/src/styles.css
+++ b/jetsclient_ide/src/styles.css
@@ -1,0 +1,369 @@
+/*
+ * One palette, defined as custom properties, consumed by both the shell and the
+ * CodeMirror theme (src/editor/theme.ts). The editor therefore follows the app's
+ * light/dark state through the cascade rather than through a second theme switch
+ * in JS.
+ */
+
+:root {
+  --ground: #f6f8f9;
+  --surface: #ffffff;
+  --surface-2: #eef1f3;
+  --ink: #131920;
+  --ink-2: #3d4855;
+  --ink-3: #6b7784;
+  --rule: #dce3e7;
+  --rule-2: #c3cdd4;
+  --accent: #0f6e78;
+  --accent-ink: #ffffff;
+  --good: #2f6b4f;
+  --warn: #8a5a0b;
+  --warn-bg: #fdf3e2;
+  --crit: #a03a31;
+  --crit-bg: #fbeae8;
+  --good-bg: #e7f3ec;
+
+  --editor-bg: #ffffff;
+  --editor-gutter: #f4f7f8;
+  --editor-active: #f2f6f7;
+  --editor-selection: #cfe6e9;
+  --editor-match: #ffeeba;
+  --editor-match-active: #ffd970;
+
+  --syn-comment: #6b7784;
+  --syn-string: #0a6b52;
+  --syn-number: #9a4a1a;
+  --syn-keyword: #0f6e78;
+  --syn-constant: #8a3fa8;
+  --syn-type: #1f5fa8;
+  --syn-namespace: #7a5230;
+  --syn-rule: #a03a31;
+  --syn-variable: #1f5fa8;
+  --syn-property: #7a5230;
+  --syn-function: #6a3fa0;
+  --syn-operator: #3d4855;
+  --syn-meta: #8a5a0b;
+
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
+}
+
+:root[data-theme="dark"] {
+  --ground: #0e1319;
+  --surface: #151b23;
+  --surface-2: #1b222b;
+  --ink: #e3e9ef;
+  --ink-2: #b3becb;
+  --ink-3: #8794a2;
+  --rule: #242e39;
+  --rule-2: #34404e;
+  --accent: #4fc3ce;
+  --accent-ink: #06232a;
+  --good: #6fb894;
+  --warn: #d6a050;
+  --warn-bg: #2e2415;
+  --crit: #e08279;
+  --crit-bg: #33201e;
+  --good-bg: #14291f;
+
+  --editor-bg: #10161d;
+  --editor-gutter: #131a22;
+  --editor-active: #182029;
+  --editor-selection: #23414a;
+  --editor-match: #3d3413;
+  --editor-match-active: #5c4d16;
+
+  --syn-comment: #71808f;
+  --syn-string: #7fc7a4;
+  --syn-number: #e0a06a;
+  --syn-keyword: #4fc3ce;
+  --syn-constant: #cd94e8;
+  --syn-type: #79b0ec;
+  --syn-namespace: #d3a171;
+  --syn-rule: #f0938a;
+  --syn-variable: #79b0ec;
+  --syn-property: #d3a171;
+  --syn-function: #b79cf0;
+  --syn-operator: #b3becb;
+  --syn-meta: #d6a050;
+}
+
+* { box-sizing: border-box; }
+
+html, body, #root { height: 100%; }
+
+body {
+  margin: 0;
+  background: var(--ground);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0);
+  white-space: nowrap; border: 0;
+}
+
+.app { display: flex; flex-direction: column; height: 100%; }
+
+/* ---------- top bar ---------- */
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--rule);
+  flex: 0 0 auto;
+}
+.brand { font-size: 13px; color: var(--ink-2); letter-spacing: -0.01em; }
+.brand strong { color: var(--ink); }
+.spacer { flex: 1 1 auto; }
+
+.ws-picker select {
+  font-family: var(--sans);
+  font-size: 13px;
+  padding: 4px 8px;
+  background: var(--surface);
+  color: var(--ink);
+  border: 1px solid var(--rule-2);
+  border-radius: 6px;
+}
+
+.btn {
+  font-family: var(--sans);
+  font-size: 13px;
+  padding: 5px 11px;
+  background: var(--surface);
+  color: var(--ink);
+  border: 1px solid var(--rule-2);
+  border-radius: 6px;
+  cursor: pointer;
+}
+.btn:hover:not(:disabled) { background: var(--surface-2); }
+.btn:disabled { opacity: 0.45; cursor: default; }
+.btn-primary {
+  background: var(--accent);
+  color: var(--accent-ink);
+  border-color: var(--accent);
+  font-weight: 600;
+}
+.btn-primary:hover:not(:disabled) { filter: brightness(1.08); }
+.btn:focus-visible, input:focus-visible, select:focus-visible, button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.pill {
+  font-size: 11.5px;
+  padding: 3px 9px;
+  border-radius: 20px;
+  background: var(--surface-2);
+  color: var(--ink-2);
+  border: 1px solid var(--rule);
+  white-space: nowrap;
+}
+.pill-warn { background: var(--warn-bg); color: var(--warn); border-color: var(--warn); }
+
+/* ---------- banners ---------- */
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  font-size: 13px;
+  border-bottom: 1px solid var(--rule);
+  flex: 0 0 auto;
+}
+.banner span { flex: 1 1 auto; }
+.banner button {
+  background: none; border: none; cursor: pointer;
+  font-size: 17px; line-height: 1; color: inherit; padding: 0 4px;
+}
+.banner-error { background: var(--crit-bg); color: var(--crit); }
+.banner-ok { background: var(--good-bg); color: var(--good); }
+
+/* ---------- layout ---------- */
+.body { display: flex; flex: 1 1 auto; min-height: 0; }
+
+.sidebar {
+  width: 290px;
+  flex: 0 0 auto;
+  background: var(--surface);
+  border-right: 1px solid var(--rule);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.main { flex: 1 1 auto; display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+
+/* ---------- file tree ---------- */
+.tree { display: flex; flex-direction: column; min-height: 0; height: 100%; }
+.tree-filter { padding: 8px; border-bottom: 1px solid var(--rule); flex: 0 0 auto; }
+.tree-filter input {
+  width: 100%;
+  font-family: var(--sans);
+  font-size: 13px;
+  padding: 5px 8px;
+  background: var(--ground);
+  color: var(--ink);
+  border: 1px solid var(--rule-2);
+  border-radius: 6px;
+}
+.tree-scroll { overflow: auto; flex: 1 1 auto; padding: 4px 0; }
+.tree-empty { color: var(--ink-3); font-size: 13px; padding: 10px 12px; }
+
+.tree-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 3px 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--ink-2);
+  font-family: var(--sans);
+  font-size: 13px;
+}
+.tree-row:hover { background: var(--surface-2); }
+.tree-file.is-active {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+.tree-file.is-active .tree-size { color: var(--accent-ink); opacity: 0.8; }
+.tree-dir { color: var(--ink); font-weight: 550; }
+.tree-label { flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tree-size {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--ink-3);
+  font-variant-numeric: tabular-nums;
+  flex: 0 0 auto;
+}
+.tree-caret { font-size: 9px; color: var(--ink-3); transition: transform 0.12s ease; display: inline-block; }
+.tree-caret.is-open { transform: rotate(90deg); }
+
+/* ---------- tabs ---------- */
+.tabbar {
+  display: flex;
+  overflow-x: auto;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--rule);
+  flex: 0 0 auto;
+}
+.tab {
+  display: flex;
+  align-items: center;
+  border-right: 1px solid var(--rule);
+  background: var(--surface-2);
+  white-space: nowrap;
+}
+.tab.is-active { background: var(--editor-bg); }
+.tab-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 6px 7px 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--ink-2);
+  font-family: var(--sans);
+  font-size: 12.5px;
+}
+.tab.is-active .tab-label { color: var(--ink); }
+.tab-close {
+  background: none; border: none; cursor: pointer;
+  color: var(--ink-3); font-size: 15px; line-height: 1;
+  padding: 0 9px 0 2px;
+}
+.tab-close:hover { color: var(--crit); }
+.dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--warn); flex: 0 0 auto;
+}
+
+/* ---------- editor ---------- */
+.editor-host { flex: 1 1 auto; min-height: 0; overflow: hidden; background: var(--editor-bg); }
+.editor-host .cm-editor { height: 100%; }
+
+.statusbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 4px 12px;
+  background: var(--surface);
+  border-top: 1px solid var(--rule);
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  flex: 0 0 auto;
+}
+.statusbar span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.empty {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: var(--ink-3);
+  background: var(--editor-bg);
+}
+.empty-sub { font-size: 12.5px; }
+
+/* ---------- login ---------- */
+.login-page {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ground);
+  padding: 20px;
+}
+.login-card {
+  width: 100%;
+  max-width: 340px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 12px;
+  padding: 26px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05), 0 12px 32px -20px rgba(0, 0, 0, 0.4);
+}
+.login-card h1 { font-size: 20px; margin: 0; letter-spacing: -0.02em; }
+.login-sub { margin: 0 0 12px; color: var(--ink-3); font-size: 13px; }
+.login-card label { font-size: 12px; color: var(--ink-2); margin-top: 8px; }
+.login-card input {
+  font-family: var(--sans);
+  font-size: 14px;
+  padding: 7px 10px;
+  background: var(--ground);
+  color: var(--ink);
+  border: 1px solid var(--rule-2);
+  border-radius: 6px;
+}
+.login-card .btn { margin-top: 16px; padding: 8px; }
+.login-error { color: var(--crit); font-size: 13px; margin: 10px 0 0; }
+.login-version {
+  margin: 12px 0 0;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation: none !important; }
+}

--- a/jetsclient_ide/tsconfig.json
+++ b/jetsclient_ide/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/jetsclient_ide/vite.config.ts
+++ b/jetsclient_ide/vite.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// The bundle is served by the Go apiserver under /ide/ (see jets/apiserver/server.go),
+// so every emitted asset url has to carry that prefix. In dev the same endpoints are
+// proxied to a locally running apiserver, which keeps the client's origin handling
+// identical in both modes — it always talks to a same-origin path.
+const API_PATHS = ["/dataTable", "/login", "/register", "/inferServer", "/registerFileKey", "/purgeData"];
+
+// The apiserver listens on :8080 with -usingSshTunnel and on :8443 (TLS) otherwise,
+// so the dev target is configurable. `secure: false` matters for the :8443 case,
+// where the certificate is self-signed.
+const apiOrigin = process.env["JETS_API_ORIGIN"] ?? "http://localhost:8080";
+
+export default defineConfig({
+  base: "/ide/",
+  plugins: [react()],
+  build: {
+    outDir: "dist",
+    // The Go handler serves whatever is here; hashed names are why the old
+    // per-file route list could not have worked.
+    assetsDir: "assets",
+    sourcemap: true,
+  },
+  server: {
+    port: 5173,
+    proxy: Object.fromEntries(
+      API_PATHS.map((p) => [p, { target: apiOrigin, changeOrigin: true, secure: false }]),
+    ),
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Phase 1 of the UI assessment: the editor beachhead. A React + TypeScript app built on CodeMirror 6, served by this apiserver at `/ide/`, running **alongside** the Flutter client rather than replacing it — same endpoints, same JWT, same `workspace_ide` capability.

## Why

The Flutter file editor is a single `TextFormField`. Flutter lays a text field's whole document out on every frame rather than virtualising by line, so cost tracks file size instead of the part on screen. That is why `mapMenuEntry` refuses anything at or above `workspaceFileEditorSizeLimit` (250,000 bytes), and why **three real `.jr` files — the largest 1.18 MB — cannot be opened in the IDE at all**.

CodeMirror virtualises by viewport, so this app has no limit and needs none. `src/api/workspace.test.ts` loads 1.2 MB to keep it that way.

## What you get

Syntax highlighting for JetRules / JSON / SQL, line numbers, find-and-replace, bracket matching, code folding, undo history, a filterable file tree, tabs with unsaved-change indicators, `Ctrl/Cmd-S` to save, and light/dark themes.

## The server contract is derived, not invented

The client mirrors the Go source, and the tests assert the exact request shapes rather than the client's idea of them:

| This app | Server |
|---|---|
| `Authorization: Bearer <token>` | `ExtractToken`, `jets/user/token.go` |
| reads `token` from **every** response | `authh` mints a fresh one per request |
| `user_email` on login | `user.User.Email` is `json:"user_email"` |
| `action` / `workspaceName` / `fromClauses[].table` / `data` | `DataTableAction` tags |
| `file_name` passed back **exactly as issued** | server escapes on tree build, unescapes on read |
| local JSON check before save | `SaveWorkspaceFileContent` refuses unparseable `.json` |

The refresh-per-response behaviour is the one most easily missed: a client that ignores `token` in each body will present a stale one and start collecting 401s. It is also stripped from the body before anything else sees it, since those bodies get rendered and the rest of the app has no business holding a credential. The token lives in memory only.

**One bug found in live testing and fixed here** (second commit): login posted `email` rather than `user_email`, so `Email` unmarshalled empty and the server answered "required Email" for a form that plainly had one. The test that should have caught it asserted my own assumption and passed while the code was wrong; it now asserts the wire field by name. Every other payload was then re-derived from the Go structs — that field was the only one wrong.

## Serving

One `PathPrefix` handler (`jets/apiserver/static_ide.go`), not the route-per-asset list the Flutter bundle uses. Not tidiness: vite emits content-hashed names, so the asset set changes every build and **cannot be enumerated in Go**. The hashing is what makes `/ide/assets/*` safe to cache immutably while `index.html` stays `no-cache`.

Anything under the prefix that is not a file falls back to `index.html` so client routes survive a reload — but a *missing* asset 404s instead, because returning the html shell surfaces as `unexpected token '<'`, which points nowhere near the cause. Traversal is closed by cleaning the path in absolute form before joining. There is a test for each.

The Flutter bundle's ~50 asset routes are **deliberately untouched**. Consolidating them means moving static registration after the API routes so a catch-all cannot shadow `/login` — worth doing when the Flutter app is retired, not as a rider on this.

## The JetRules mode

Ported from `tools/vscode-jetrule/syntaxes/jetrule.tmLanguage.json`, which stays the reference. Fourteen top-level patterns made porting cheaper than carrying `vscode-textmate` plus an Oniguruma wasm build to reuse it. A stream tokeniser rather than Lezer because highlighting is all that is needed today; folding by rule, structural selection and go-to-definition all want a tree, and that is the point to invest in one. **Keep the two in step** — something the VS Code extension highlights and this does not is a bug in the mode.

## Deploying

```bash
cd jetsclient_ide && npm install && npm run build

IDE_APP_DEPLOYMENT_DIR=/path/to/jetsclient_ide/dist \
WORKSPACES_HOME=... WORKSPACE=... JETS_DSN=... API_SECRET=... \
apiserver -usingSshTunnel
```

Then `/ide/`. The flag is `-IDE_APP_DEPLOYMENT_DIR` with a matching env override, the same arrangement `WEB_APP_DEPLOYMENT_DIR` uses. **If it points nowhere, `/ide/` answers a plain 404 and the server still starts** — so this is safe to merge before any deployment change.

Flutter gains one menu entry, **Code Editor ↗**, gated on `workspace_ide`. No `routePath`, so it never joins the page stack; opens in a tab rather than an iframe because the two apps would otherwise fight over routing and editor keybindings.

## Verification

| Check | Result |
|---|---|
| `npm test` | **43 pass** |
| `tsc --noEmit` + `vite build` | clean — 594 kB raw / **193 kB gzipped** |
| `go build` / `go vet` / `go test ./jets/apiserver` | **7 pass** |
| `flutter analyze` | **127** — unchanged baseline |
| `flutter build web --release` | clean |

The Go test worth noting serves the **real** vite-built bundle through the **real** handler and fetches every asset url out of the emitted html — so vite's `base` and the Go prefix are checked against each other rather than assumed.

Sign-in and the editor have now been exercised against a live apiserver on `jets_ws`.

## Known gaps

- **The session is not shared.** The IDE holds its token in memory, so opening it costs a second sign-in. Fixing it properly means deciding where a token may be persisted — a security decision, not a coding one.
- **`package-lock.json` is excluded by the root `.gitignore`**, so the dependency set is not pinned in-tree and builds are not reproducible. Left as the repo has it, but it should be a deliberate choice.
- Not here: creating/renaming/deleting files, git operations, the workspace-registry screens, the Query Tool, diffing against the committed version, and the pipeline-config and data-model section forms. All remain in the Flutter app — which is why the two run side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
