### PR TITLE
Give the Workspace IDE its own favicon

### DIFF
--- a/jets/apiserver/static_ide_test.go
+++ b/jets/apiserver/static_ide_test.go
@@ -144,6 +144,34 @@ func TestIdeHandlerServesTheRealBundle(t *testing.T) {
 	}
 }
 
+// TestIdeShipsItsOwnFavicon guards a dependency that is easy to reintroduce by
+// accident. With no <link rel="icon"> the browser falls back to /favicon.ico at
+// the origin root, which is the *Flutter* app's icon: the IDE then shows no tab
+// icon at all unless WEB_APP_DEPLOYMENT_DIR happens to be set, and shows the
+// wrong one when it is. The icon has to ship with this bundle and be declared.
+func TestIdeShipsItsOwnFavicon(t *testing.T) {
+	dir, err := filepath.Abs(filepath.Join("..", "..", "jetsclient_ide", "dist"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	index, err := os.ReadFile(filepath.Join(dir, "index.html"))
+	if err != nil {
+		t.Skip("jetsclient_ide/dist not built; run `npm run build` in jetsclient_ide")
+	}
+
+	icon := regexp.MustCompile(`rel="icon"[^>]*href="([^"]+)"`).FindSubmatch(index)
+	if icon == nil {
+		t.Fatal("index.html declares no rel=icon; the browser would fall back to the Flutter favicon")
+	}
+	href := string(icon[1])
+	if !strings.HasPrefix(href, ideAssetPrefix) {
+		t.Fatalf("favicon %q is not under %q, so it does not come from this bundle", href, ideAssetPrefix)
+	}
+	if res := get(t, ideHandler(ideAssetPrefix, dir), href); res.Code != http.StatusOK {
+		t.Fatalf("favicon %q: got %d, want 200", href, res.Code)
+	}
+}
+
 func TestIdeHandlerReportsMissingDeployment(t *testing.T) {
 	// An apiserver built without the IDE bundle should say so rather than 500.
 	h := ideHandler(ideAssetPrefix, filepath.Join(t.TempDir(), "absent"))

--- a/jetsclient_ide/index.html
+++ b/jetsclient_ide/index.html
@@ -3,6 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Declared explicitly rather than left to the browser's implicit request for
+      /favicon.ico at the origin root. That fallback resolves to the *Flutter*
+      app's icon, only works when WEB_APP_DEPLOYMENT_DIR is set, and gives the two
+      apps the same tab. This one ships with the bundle, so it holds whether or
+      not the Flutter app is deployed.
+
+      Written with a leading slash so vite rewrites it with the configured base;
+      a relative href would resolve against the current document and break on a
+      deep client route, which is served this same html from a different path.
+    -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>JetStore Workspace IDE</title>
   </head>
   <body>

--- a/jetsclient_ide/public/favicon.svg
+++ b/jetsclient_ide/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="JetStore Workspace IDE">
+  <!--
+    A rule header, [ ], which is how every JetRules rule opens. Solid ground
+    rather than a transparent glyph so it reads on a light or a dark tab strip
+    without needing two files, and only three strokes so it survives 16px.
+  -->
+  <rect width="32" height="32" rx="7" fill="#0f6e78"/>
+  <g fill="none" stroke="#ffffff" stroke-width="2.75" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M13 9.5 H9.5 V22.5 H13"/>
+    <path d="M19 9.5 H22.5 V22.5 H19"/>
+  </g>
+  <circle cx="16" cy="16" r="1.9" fill="#7fe3ec"/>
+</svg>


### PR DESCRIPTION
The /ide/ tab showed no icon even though /favicon.ico returned one. index.html declared no rel=icon, so the browser fell back to requesting /favicon.ico at the origin root - which is the Flutter app's icon, served by the Flutter file server out of WEB_APP_DEPLOYMENT_DIR. That fallback is wrong twice over: it only resolves when the Flutter bundle is deployed, and when it does resolve it gives the two apps the same tab, which is a poor trade for an app whose whole point is to open in a second tab beside the first. It also explains why the icon stayed blank after WEB_APP_DEPLOYMENT_DIR was fixed: browsers cache a failed favicon fetch aggressively, and nothing about the page had changed to prompt a retry.

The icon now ships with this bundle and is declared. It is an svg rather than an ico so it stays crisp at any density in one 653-byte file, and it draws a rule header - the [ ] that opens every JetRules rule - on solid ground rather than as a transparent glyph, so it reads against a light or a dark tab strip without needing a second asset or a prefers-color-scheme branch. Three strokes, because anything more turns to mud at 16 pixels.

The href is written with a leading slash so vite rewrites it with the configured base, which is verified in the build output as /ide/favicon.svg. A relative href would resolve against the current document and 404 on a deep client route, since those are served this same html from a different path.

TestIdeShipsItsOwnFavicon asserts the declaration exists, that it points inside this bundle rather than at the origin root, and that the handler serves it. The existing real-bundle test already fetched it incidentally once the href was there; a dedicated test states the requirement instead of covering it by accident, which matters because the failure mode here is silent.